### PR TITLE
Refactor hint_font function location

### DIFF
--- a/foundrytools_cli_2/lib/otf/afdko_tools.py
+++ b/foundrytools_cli_2/lib/otf/afdko_tools.py
@@ -1,13 +1,10 @@
 import typing as t
 from contextlib import contextmanager
-from pathlib import Path
 
-from afdko.otfautohint.__main__ import ACOptions, _validate_path
-from afdko.otfautohint.autohint import FontInstance, fontWrapper, openFont
 from cffsubr import desubroutinize, subroutinize
 from fontTools.ttLib import TTFont
 
-__all__ = ["cff_subr", "cff_desubr", "hint_font"]
+__all__ = ["cff_subr", "cff_desubr"]
 
 
 @contextmanager
@@ -49,26 +46,3 @@ def cff_desubr(font: TTFont) -> None:
     _validate_sfnt_version(font=font)
     with _restore_flavor(font):
         desubroutinize(otf=font)
-
-
-def hint_font(
-    in_file: Path,
-    options: ACOptions,
-) -> TTFont:
-    """
-    Applies hinting to an OpenType-PS font file and returns the hinted TTFont object.
-
-    Parameters:
-        in_file: Path to the font file.
-        options: An ACOptions object containing the options to use for hinting.
-
-    Returns:
-        TTFont: A hinted TTFont object.
-    """
-
-    in_file = _validate_path(in_file)
-    font = openFont(in_file, options=options)
-    font_instance = FontInstance(font=font, inpath=in_file, outpath=None)
-    fw = fontWrapper(options=options, fil=[font_instance])
-    fw.hint()
-    return fw.fontInstances[0].font.ttFont

--- a/foundrytools_cli_2/snippets/otf/autohint.py
+++ b/foundrytools_cli_2/snippets/otf/autohint.py
@@ -1,12 +1,36 @@
 import typing as t
 from pathlib import Path
 
-from afdko.otfautohint.__main__ import ACOptions
+from afdko.otfautohint.__main__ import ACOptions, _validate_path
+from afdko.otfautohint.autohint import FontInstance, fontWrapper, openFont
+from fontTools.ttLib import TTFont
 
 from foundrytools_cli_2.lib.font import Font
-from foundrytools_cli_2.lib.otf.afdko_tools import hint_font
 
 from . import get_file_to_process
+
+
+def hint_font(
+    in_file: Path,
+    options: ACOptions,
+) -> TTFont:
+    """
+    Applies hinting to an OpenType-PS font file and returns the hinted TTFont object.
+
+    Parameters:
+        in_file: Path to the font file.
+        options: An ACOptions object containing the options to use for hinting.
+
+    Returns:
+        TTFont: A hinted TTFont object.
+    """
+
+    in_file = _validate_path(in_file)
+    font = openFont(in_file, options=options)
+    font_instance = FontInstance(font=font, inpath=in_file, outpath=None)
+    fw = fontWrapper(options=options, fil=[font_instance])
+    fw.hint()
+    return fw.fontInstances[0].font.ttFont
 
 
 def main(


### PR DESCRIPTION
This commit relocates the hint_font function from the afdko_tools.py to the autohint.py module. This change also includes importing necessary modules for the hint_font function to the autohint.py module and removing it from afdko_tools.py list of exports.