### PR TITLE
Fix flavor handling in recalc_stems.py

### DIFF
--- a/foundrytools_cli_2/snippets/otf/recalc_stems.py
+++ b/foundrytools_cli_2/snippets/otf/recalc_stems.py
@@ -22,7 +22,7 @@ def main(font: Font) -> None:
     flavor = font.ttfont.flavor
     temp_file = get_temp_file_path()
     if flavor is not None:
-        font.to_sfnt()
+        font.ttfont.flavor = None
         font.save(temp_file)
         input_file = temp_file
     else:


### PR DESCRIPTION
Use 'font.ttfont.flavor = None' instead of 'font.to_sfnt' to avoid saving font to file even if stems have not changed