### PR TITLE
Change font-to-SFNT call to resetting font flavor in 'get_file_to_process'

### DIFF
--- a/foundrytools_cli_2/snippets/otf/__init__.py
+++ b/foundrytools_cli_2/snippets/otf/__init__.py
@@ -21,7 +21,7 @@ def get_file_to_process(
 
     flavor = font.ttfont.flavor
     if flavor is not None:
-        font.to_sfnt()
+        font.ttfont.flavor = None
 
     if in_file != out_file or flavor is not None:
         font.save(out_file)


### PR DESCRIPTION
The previous implementation used 'font.to_sfnt' method to convert the font to SFNT format if certain conditions were met, which was not the intended functionality. This commit changes it to 'font.ttfont.flavor = None', which is more correct because the 'font.modified' attribute is not changed (which happens with 'font.to_sfnt').