### PR TITLE
Refactor contours correction in font processing

### DIFF
--- a/foundrytools_cli_2/cli/otf/cli.py
+++ b/foundrytools_cli_2/cli/otf/cli.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import click
 
-from foundrytools_cli_2.cli.otf.options import min_area_option, otf_autohint_options
-from foundrytools_cli_2.cli.shared_options import base_options, subroutinize_flag
+from foundrytools_cli_2.cli.otf.options import otf_autohint_options
+from foundrytools_cli_2.cli.shared_options import base_options, min_area_option, subroutinize_flag
 from foundrytools_cli_2.lib.font import Font
 from foundrytools_cli_2.lib.font_runner import FontRunner
 

--- a/foundrytools_cli_2/cli/otf/options.py
+++ b/foundrytools_cli_2/cli/otf/options.py
@@ -5,24 +5,6 @@ import click
 from foundrytools_cli_2.cli.shared_options import add_options
 
 
-def min_area_option() -> t.Callable:
-    """
-    Add the min_area option to a click command.
-
-    :return: a decorator that adds the min_area option to a click command
-    """
-    _min_area_option = [
-        click.option(
-            "-ma",
-            "--min-area",
-            type=click.IntRange(min=0),
-            default=25,
-            help="Remove tiny paths with area less than the specified value.",
-        )
-    ]
-    return add_options(_min_area_option)
-
-
 def otf_autohint_options() -> t.Callable:
     """
     Add the autohint options to a click command.

--- a/foundrytools_cli_2/cli/otf/snippets/fix_contours.py
+++ b/foundrytools_cli_2/cli/otf/snippets/fix_contours.py
@@ -19,11 +19,14 @@ def main(font: Font, min_area: int = 25, subroutinize: bool = True) -> None:
     """
     logger.info("Correcting contours...")
     modified = font.ps_correct_contours(min_area=min_area)
+
     if not modified:
         logger.info("No contours were modified")
         return
 
+    font.modified = True
     logger.info(f"{len(modified)} contours were modified")
+
     if subroutinize:
         logger.info("Subroutinizing...")
         font.ps_subroutinize()

--- a/foundrytools_cli_2/cli/shared_options.py
+++ b/foundrytools_cli_2/cli/shared_options.py
@@ -268,3 +268,21 @@ def subroutinize_flag() -> t.Callable:
         )
     ]
     return add_options(_subroutinize_flag)
+
+
+def min_area_option() -> t.Callable:
+    """
+    Add the min_area option to a click command.
+
+    :return: a decorator that adds the min_area option to a click command
+    """
+    _min_area_option = [
+        click.option(
+            "-ma",
+            "--min-area",
+            type=click.IntRange(min=0),
+            default=25,
+            help="Remove tiny paths with area less than the specified value.",
+        )
+    ]
+    return add_options(_min_area_option)

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -28,7 +28,8 @@ from foundrytools_cli_2.lib.constants import (
 )
 from foundrytools_cli_2.lib.font.tables import HeadTable, OS2Table
 from foundrytools_cli_2.lib.otf.otf_builder import build_otf
-from foundrytools_cli_2.lib.otf.t2_charstrings import fix_charstrings, quadratics_to_cubics
+from foundrytools_cli_2.lib.otf.t2_charstrings import quadratics_to_cubics
+from foundrytools_cli_2.lib.pathops.skia_tools import correct_contours_cff
 from foundrytools_cli_2.lib.ttf.ttf_builder import build_ttf
 from foundrytools_cli_2.lib.utils.misc import restore_flavor
 from foundrytools_cli_2.lib.utils.path_tools import get_temp_file_path
@@ -582,11 +583,15 @@ class Font:  # pylint: disable=too-many-public-methods
                 "PS Contour correction is only supported for PostScript flavored fonts."
             )
 
-        charstrings, modified_glyphs = fix_charstrings(font=self.ttfont, min_area=min_area)
+        if self.is_variable:
+            raise NotImplementedError(
+                "PS Contour correction is not supported for variable fonts."
+            )
+
+        charstrings, modified_glyphs = correct_contours_cff(font=self.ttfont, min_area=min_area)
         if not modified_glyphs:
             return []
         build_otf(font=self.ttfont, charstrings_dict=charstrings)
-        self.modified = True
         return modified_glyphs
 
     def ps_subroutinize(self) -> None:


### PR DESCRIPTION
The contour correction process for OpenType-PS fonts was refactored. We moved the correction logic from `t2_charstrings.py` to `skia_tools.py` for better organization and moved the setting of `font.modified` to align with contour modification. This change should make the contour correction process clearer and more manageable. The `min_area_option` has been moved to `shared_options` module for future use in the OpenType-TT contours direction