### PR TITLE
Update command group help text formatting

### DIFF
--- a/foundrytools_cli_2/cli/gsub/cli.py
+++ b/foundrytools_cli_2/cli/gsub/cli.py
@@ -8,7 +8,7 @@ import click
 from foundrytools_cli_2.cli.shared_options import base_options
 from foundrytools_cli_2.lib.font_runner import FontRunner
 
-cli = click.Group(help="Utilities for editing the GSUB table.")
+cli = click.Group(help="Utilities for editing the ``GSUB`` table.")
 
 
 @cli.command("rename-feature")

--- a/foundrytools_cli_2/cli/name/cli.py
+++ b/foundrytools_cli_2/cli/name/cli.py
@@ -19,7 +19,7 @@ from foundrytools_cli_2.cli.name.options import (
 from foundrytools_cli_2.cli.shared_options import base_options
 from foundrytools_cli_2.lib.font_runner import FontRunner
 
-cli = click.Group(help="Utilities for editing the name table.")
+cli = click.Group(help="Utilities for editing the ``name`` table.")
 
 
 @cli.command("del-names")

--- a/foundrytools_cli_2/cli/os_2/cli.py
+++ b/foundrytools_cli_2/cli/os_2/cli.py
@@ -12,7 +12,7 @@ from foundrytools_cli_2.cli.os_2.options import (
 from foundrytools_cli_2.cli.shared_options import base_options
 from foundrytools_cli_2.lib.font_runner import FontRunner
 
-cli = click.Group(help="Utilities for editing the OS/2 table.")
+cli = click.Group(help="Utilities for editing the ``OS/2`` table.")
 
 
 @cli.command("recalc-avg-width")

--- a/foundrytools_cli_2/cli/post/cli.py
+++ b/foundrytools_cli_2/cli/post/cli.py
@@ -38,7 +38,7 @@ from foundrytools_cli_2.lib.font_runner import FontRunner
 @base_options()
 def cli(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     """
-    A command line tool to manipulate the 'post' table.
+    A command line tool to manipulate the ``post`` table.
     """
     from foundrytools_cli_2.cli.post.snipptes import set_attrs as task
 


### PR DESCRIPTION
Double backticks were added around the table names such as "GSUB", "post", "OS/2" and "name" in the help text of the command groups in the cli.py files