### PR TITLE
Handle PermissionError in font finder

### DIFF
--- a/foundrytools_cli_2/lib/font_finder.py
+++ b/foundrytools_cli_2/lib/font_finder.py
@@ -97,7 +97,7 @@ class FontFinder:
                 )
                 if not any(condition and func(font) for condition, func in self._filter_conditions):
                     yield font
-            except TTLibError:
+            except (TTLibError, PermissionError):
                 pass
 
     def _generate_files(self) -> t.Generator[Path, None, None]:


### PR DESCRIPTION
The font finder script has been updated to also catch PermissionError exceptions, preventing the application from crashing when it encounters such an error. Previously, it was only handling TTLibError exceptions.