### PR TITLE
Dev

### DIFF
--- a/foundrytools_cli_2/cli/os_2/cli.py
+++ b/foundrytools_cli_2/cli/os_2/cli.py
@@ -65,37 +65,9 @@ def recalc_max_context(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     runner.run()
 
 
-@cli.command("recalc-unicode-ranges")
+@cli.command("recalc-ranges")
 @base_options()
-def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
-    """
-    Recalculates the ulUnicodeRange values of the OS/2 table.
-
-    The ulUnicodeRanges values are calculated using the fontTools library.
-    """
-    from foundrytools_cli_2.cli.os_2.snippets import recalc_unicode_ranges as task
-
-    runner = FontRunner(input_path=input_path, task=task, **options)
-    runner.run()
-
-
-@cli.command("recalc-codepage-ranges")
-@base_options()
-def recalc_codepage_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
-    """
-    Recalculates the ulCodePageRange values of the OS/2 table.
-
-    The ulCodePageRanges values are calculated using the fontTools library.
-    """
-    from foundrytools_cli_2.cli.os_2.snippets import recalc_codepage_ranges as task
-
-    runner = FontRunner(input_path=input_path, task=task, **options)
-    runner.run()
-
-
-@cli.command("recalc-ranges-afdko")
-@base_options()
-def recalc_ranges_afdko(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     """
     Recalculates the ulUnicodeRange and ulCodePageRange values of the OS/2 table using AFDKO.
 

--- a/foundrytools_cli_2/cli/ttf/cli.py
+++ b/foundrytools_cli_2/cli/ttf/cli.py
@@ -16,10 +16,12 @@ cli = click.Group(help="Utilities for editing OpenType-TT fonts.")
 @base_options()
 def autohint(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     """
-    Autohints the given TrueType fonts.
+    Auto-hints the given TrueType fonts using ttfautohint-py.
     """
 
-    runner = FontRunner(input_path=input_path, task=Font.tt_autohint, **options)
+    from foundrytools_cli_2.cli.ttf.snippets.autohint import ttf_autohint as task
+
+    runner = FontRunner(input_path=input_path, task=task, **options)
     runner.filter.filter_out_ps = True
     runner.run()
 

--- a/foundrytools_cli_2/cli/ttf/cli.py
+++ b/foundrytools_cli_2/cli/ttf/cli.py
@@ -33,7 +33,9 @@ def dehint(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Removes hinting from the given TrueType fonts.
     """
 
-    runner = FontRunner(input_path=input_path, task=Font.tt_remove_hints, **options)
+    from foundrytools_cli_2.cli.ttf.snippets.dehint import ttf_dehint as task
+
+    runner = FontRunner(input_path=input_path, task=task, **options)
     runner.filter.filter_out_ps = True
     runner.run()
 

--- a/foundrytools_cli_2/cli/ttf/snippets/autohint.py
+++ b/foundrytools_cli_2/cli/ttf/snippets/autohint.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+
+from fontTools.ttLib import TTFont
+from ttfautohint import ttfautohint
+
+from foundrytools_cli_2.lib.constants import HEAD_TABLE_TAG
+from foundrytools_cli_2.lib.font import Font
+
+
+def ttf_autohint(font: Font) -> None:
+    """
+    Auto-hints the given TrueType font.
+
+    Args:
+        font (Font): The Font object.
+    """
+
+    if not font.is_tt:
+        raise ValueError("TTF auto-hinting is only supported for TrueType fonts.")
+
+    with BytesIO() as buffer:
+        flavor = font.ttfont.flavor
+        font.ttfont.flavor = None
+        font.save(buffer, reorder_tables=None)
+        data = ttfautohint(in_buffer=buffer.getvalue(), no_info=True)
+        hinted_font = TTFont(BytesIO(data), recalcTimestamp=False)
+        hinted_font.flavor = flavor
+        hinted_font[HEAD_TABLE_TAG].modified = font.ttfont[HEAD_TABLE_TAG].modified
+        font.ttfont = hinted_font
+        font.modified = True

--- a/foundrytools_cli_2/cli/ttf/snippets/autohint.py
+++ b/foundrytools_cli_2/cli/ttf/snippets/autohint.py
@@ -16,7 +16,7 @@ def ttf_autohint(font: Font) -> None:
     """
 
     if not font.is_tt:
-        raise ValueError("TTF auto-hinting is only supported for TrueType fonts.")
+        raise NotImplementedError("TTF auto-hinting is only supported for TrueType fonts.")
 
     with BytesIO() as buffer:
         flavor = font.ttfont.flavor

--- a/foundrytools_cli_2/cli/ttf/snippets/dehint.py
+++ b/foundrytools_cli_2/cli/ttf/snippets/dehint.py
@@ -12,7 +12,7 @@ def ttf_dehint(font: Font) -> None:
     """
 
     if not font.is_tt:
-        raise ValueError("TTF de-hinting is only supported for TrueType fonts.")
+        raise NotImplementedError("TTF de-hinting is only supported for TrueType fonts.")
 
     dehint(font.ttfont, verbose=False)
     font.modified = True

--- a/foundrytools_cli_2/cli/ttf/snippets/dehint.py
+++ b/foundrytools_cli_2/cli/ttf/snippets/dehint.py
@@ -1,0 +1,18 @@
+from dehinter.font import dehint
+
+from foundrytools_cli_2.lib.font import Font
+
+
+def ttf_dehint(font: Font) -> None:
+    """
+    De-hints the given TrueType font.
+
+    Args:
+        font (Font): The Font object.
+    """
+
+    if not font.is_tt:
+        raise ValueError("TTF de-hinting is only supported for TrueType fonts.")
+
+    dehint(font.ttfont, verbose=False)
+    font.modified = True

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -4,7 +4,6 @@ from io import BytesIO
 from pathlib import Path
 
 from cffsubr import desubroutinize, subroutinize
-from dehinter.font import dehint
 from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.recordingPen import DecomposingRecordingPen
 from fontTools.pens.statisticsPen import StatisticsPen
@@ -636,16 +635,6 @@ class Font:  # pylint: disable=too-many-public-methods
             except KeyError:
                 continue
         raise ValueError("The font does not contain the glyph 'H' or 'uni0048'.")
-
-    def tt_remove_hints(self) -> None:
-        """
-        Remove hints from a TrueType font.
-        """
-        if not self.is_tt:
-            raise NotImplementedError("Only TrueType fonts are supported.")
-
-        dehint(self.ttfont, verbose=False)
-        self.modified = True
 
     def tt_decomponentize(self) -> None:
         """

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -12,7 +12,6 @@ from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.scaleUpem import scale_upem
 from fontTools.ttLib.tables._f_v_a_r import Axis, NamedInstance
-from ttfautohint import ttfautohint
 
 from foundrytools_cli_2.lib.constants import (
     FVAR_TABLE_TAG,
@@ -637,23 +636,6 @@ class Font:  # pylint: disable=too-many-public-methods
             except KeyError:
                 continue
         raise ValueError("The font does not contain the glyph 'H' or 'uni0048'.")
-
-    def tt_autohint(self, recalc_timestamp: bool = False) -> None:
-        """
-        Autohint a TrueType font using ttfautohint-py.
-        """
-        if not self.is_tt:
-            raise NotImplementedError("TTF auto-hinting is only supported for TrueType fonts.")
-
-        buf = BytesIO()
-        self.save(buf, reorder_tables=None)
-        data = ttfautohint(in_buffer=buf.getvalue(), no_info=True)
-        hinted_font = TTFont(BytesIO(data), recalcTimestamp=recalc_timestamp)
-        if not recalc_timestamp:
-            hinted_font[HEAD_TABLE_TAG].modified = self.ttfont[HEAD_TABLE_TAG].modified
-        self.ttfont = hinted_font
-        self.modified = True
-        buf.close()
 
     def tt_remove_hints(self) -> None:
         """

--- a/foundrytools_cli_2/lib/logger.py
+++ b/foundrytools_cli_2/lib/logger.py
@@ -11,7 +11,7 @@ logger.add(
     sys.stderr,
     backtrace=False,
     colorize=True,
-    format="[ <level>{level: <8}</level> ] " "<level>{message}</level>",
+    format="[ <level>{level: <8}</level> ] " "{message}",
     level="INFO",
 )
 


### PR DESCRIPTION
- Use only 'tx' method to recalculate OS/2 ranges
- Logger: colorize only log level, not log message
- Move TTF autohint/dehint out of library