### PR TITLE
Add legacy accents check and GDEF table handling

### DIFF
--- a/foundrytools_cli_2/cli/fix/cli.py
+++ b/foundrytools_cli_2/cli/fix/cli.py
@@ -122,3 +122,27 @@ def fix_monospace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
     runner = TaskRunner(input_path=input_path, task=task, **options)
     runner.run()
+
+
+@cli.command("legacy-accents")
+@base_options()
+def fix_legacy_accents(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+    """
+    Check that legacy accents aren't used in composite glyphs.
+
+    fontbakery check id: com.google.fonts/check/legacy_accents
+
+    Rationale:
+
+    Legacy accents should not have anchors and should have positive width. They are often used
+    independently of a letter, either as a placeholder for an expected combined mark+letter
+    combination in macOS, or separately. For instance, U+00B4 (ACUTE ACCENT) is often mistakenly
+    used as an apostrophe, U+0060 (GRAVE ACCENT) is used in Markdown to notify code blocks, and ^ is
+    used as an exponential operator in maths.
+
+    More info: https://github.com/googlefonts/fontbakery/issues/4310
+    """
+    from foundrytools_cli_2.cli.fix.snippets.legacy_accents import fix_legacy_accents as task
+
+    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner.run()

--- a/foundrytools_cli_2/cli/fix/snippets/legacy_accents.py
+++ b/foundrytools_cli_2/cli/fix/snippets/legacy_accents.py
@@ -1,0 +1,51 @@
+from foundrytools_cli_2.cli.logger import logger
+from foundrytools_cli_2.lib.constants import T_CMAP, T_GDEF, T_HMTX
+from foundrytools_cli_2.lib.font import Font
+from foundrytools_cli_2.lib.font.tables import GdefTable
+
+
+def fix_legacy_accents(font: Font) -> None:
+    """Check that legacy accents aren't used in composite glyphs."""
+
+    # code-points for all legacy chars
+    legacy_accents = {
+        0x00A8,  # DIAERESIS
+        0x02D9,  # DOT ABOVE
+        0x0060,  # GRAVE ACCENT
+        0x00B4,  # ACUTE ACCENT
+        0x02DD,  # DOUBLE ACUTE ACCENT
+        0x02C6,  # MODIFIER LETTER CIRCUMFLEX ACCENT
+        0x02C7,  # CARON
+        0x02D8,  # BREVE
+        0x02DA,  # RING ABOVE
+        0x02DC,  # SMALL TILDE
+        0x00AF,  # MACRON
+        0x00B8,  # CEDILLA
+        0x02DB,  # OGONEK
+    }
+
+    reverse_cmap = font.ttfont[T_CMAP].buildReversed()
+    hmtx = font.ttfont[T_HMTX]
+
+    # Check whether legacy accents have positive width. Just print a warning if they don't.
+    for name in reverse_cmap:
+        if reverse_cmap[name].intersection(legacy_accents) and hmtx[name][0] == 0:
+            logger.warning(
+                f'Width of legacy accent "{name}" is zero; should be positive.',
+            )
+
+    # Check whether legacy accents appear in GDEF as marks.
+    # Not being marks in GDEF also typically means that they don't have anchors, as font compilers
+    # would have otherwise classified them as marks in GDEF.
+    if T_GDEF in font.ttfont and font.ttfont[T_GDEF].table.GlyphClassDef:
+        gdef = GdefTable(ttfont=font.ttfont)
+        class_defs = gdef.table.table.GlyphClassDef.classDefs
+        for name in reverse_cmap:
+            if (
+                reverse_cmap[name].intersection(legacy_accents)
+                and name in class_defs
+                and class_defs[name] == 3
+            ):
+                del class_defs[name]
+                logger.info(f'"{name}" was defined in GDEF as a mark (class 3). Removed.')
+        font.modified = gdef.modified

--- a/foundrytools_cli_2/lib/font/tables/__init__.py
+++ b/foundrytools_cli_2/lib/font/tables/__init__.py
@@ -1,4 +1,5 @@
 from foundrytools_cli_2.lib.font.tables.cff_ import CFFTable
+from foundrytools_cli_2.lib.font.tables.gdef import GdefTable
 from foundrytools_cli_2.lib.font.tables.glyf import GlyfTable
 from foundrytools_cli_2.lib.font.tables.gsub import GsubTable
 from foundrytools_cli_2.lib.font.tables.head import HeadTable
@@ -9,6 +10,7 @@ from foundrytools_cli_2.lib.font.tables.post import PostTable
 
 __all__ = [
     "CFFTable",
+    "GdefTable",
     "GlyfTable",
     "GsubTable",
     "HeadTable",

--- a/foundrytools_cli_2/lib/font/tables/gdef.py
+++ b/foundrytools_cli_2/lib/font/tables/gdef.py
@@ -1,0 +1,16 @@
+from fontTools.ttLib import TTFont
+
+from foundrytools_cli_2.lib.constants import T_GDEF
+from foundrytools_cli_2.lib.font.tables.default import DefaultTbl
+
+
+class GdefTable(DefaultTbl):  # pylint: disable=too-few-public-methods
+    """
+    This class extends the fontTools ``GDEF`` table.
+    """
+
+    def __init__(self, ttfont: TTFont) -> None:
+        """
+        Initializes the ``GSUB`` table handler.
+        """
+        super().__init__(ttfont=ttfont, table_tag=T_GDEF)


### PR DESCRIPTION
Fixes `fontbakery` check `com.google.fonts/check/legacy_accents`

See: https://github.com/googlefonts/fontbakery/issues/4310