### PR TITLE
Add removal of duplicate components in composite glyphs

### DIFF
--- a/foundrytools_cli_2/cli/fix/cli.py
+++ b/foundrytools_cli_2/cli/fix/cli.py
@@ -187,3 +187,31 @@ def fix_transformed_components(input_path: Path, **options: t.Dict[str, t.Any]) 
     runner.filter.filter_out_ps = True
     runner.filter.filter_out_variable = True
     runner.run()
+
+
+@cli.command("duplicate-components")
+@base_options()
+def fix_duplicate_components(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+    """
+    Remove duplicate components.
+
+    fontbakery check id: com.google.fonts/check/glyf_non_transformed_duplicate_components
+
+    Rationale:
+
+    There have been cases in which fonts had faulty double quote marks, with each of them
+    containing two single quote marks as components with the same x, y coordinates which makes
+    them visually look like single quote marks.
+
+    This check ensures that glyphs do not contain duplicate components which have the same x,
+    y coordinates.
+
+    Fixing procedure:
+
+    * Remove duplicate components which have the same x,y coordinates.
+    """
+    from foundrytools_cli_2.cli.fix.snippets.duplicate_components import main as task
+
+    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner.filter.filter_out_ps = True
+    runner.run()

--- a/foundrytools_cli_2/cli/fix/snippets/duplicate_components.py
+++ b/foundrytools_cli_2/cli/fix/snippets/duplicate_components.py
@@ -1,0 +1,14 @@
+from foundrytools_cli_2.cli.logger import logger
+from foundrytools_cli_2.lib.font import Font
+from foundrytools_cli_2.lib.font.tables import GlyfTable
+
+
+def main(font: Font) -> None:
+    """Decompose composite glyphs that have transformed components."""
+    glyf = GlyfTable(ttfont=font.ttfont)
+    fixed_glyphs = glyf.remove_duplicate_components()
+    if fixed_glyphs:
+        logger.info(
+            f"Removed duplicate components in the following glyphs: {', '.join(fixed_glyphs)}"
+        )
+        font.modified = True

--- a/foundrytools_cli_2/lib/font/tables/glyf.py
+++ b/foundrytools_cli_2/lib/font/tables/glyf.py
@@ -71,3 +71,25 @@ class GlyfTable(DefaultTbl):  # pylint: disable=too-few-public-methods
                 decomposed_glyphs.add(glyph_name)
 
         return decomposed_glyphs
+
+    def remove_duplicate_components(self) -> t.Set[str]:
+        """
+        Remove duplicate components from composite glyphs.
+        """
+        fixed_glyphs = set()
+        for glyph_name in self.ttfont.getGlyphOrder():
+            glyph = self.table[glyph_name]
+            if not glyph.isComposite():
+                continue
+
+            components = []
+            for component in glyph.components:
+                if component not in components:
+                    components.append(component)
+                else:
+                    fixed_glyphs.add(glyph_name)
+
+            glyph.components = components
+            self.table[glyph_name] = glyph
+
+        return fixed_glyphs


### PR DESCRIPTION
Implemented a method to remove duplicate components in composite glyphs within the `glyf` table. Added a CLI command to initiate this process and log the names of the affected glyphs.