### PR TITLE
Refactor `old_string` and `new_string` option definitions.

### DIFF
--- a/foundrytools_cli_2/cli/name/cli.py
+++ b/foundrytools_cli_2/cli/name/cli.py
@@ -11,13 +11,11 @@ from foundrytools_cli_2.cli.name.options import (
     name_id,
     name_ids,
     name_string,
-    new_string,
-    old_string,
     platform_id,
     skip_name_ids,
     win_or_mac_platform_id,
 )
-from foundrytools_cli_2.cli.shared_options import base_options
+from foundrytools_cli_2.cli.shared_options import base_options, new_string, old_string
 from foundrytools_cli_2.cli.task_runner import TaskRunner
 
 cli = click.Group(help="Utilities for editing the ``name`` table.")

--- a/foundrytools_cli_2/cli/name/options.py
+++ b/foundrytools_cli_2/cli/name/options.py
@@ -184,48 +184,6 @@ def name_string() -> t.Callable:
     return add_options(_string_option)
 
 
-def old_string() -> t.Callable:
-    """
-    Add the ``old_string`` option to a click command.
-
-    Returns:
-        t.Callable: A decorator that adds the old_string option to a click command
-    """
-    _old_string_option = [
-        click.option(
-            "-os",
-            "--old-string",
-            type=str,
-            required=True,
-            help="""
-            Specify the string to be replaced.
-            """,
-        )
-    ]
-    return add_options(_old_string_option)
-
-
-def new_string() -> t.Callable:
-    """
-    Add the ``new_string`` option to a click command.
-
-    Returns:
-        t.Callable: A decorator that adds the new_string option to a click command
-    """
-    _new_string_option = [
-        click.option(
-            "-ns",
-            "--new-string",
-            type=str,
-            required=True,
-            help="""
-            Specify the string to replace the old string with.
-            """,
-        )
-    ]
-    return add_options(_new_string_option)
-
-
 def delete_all() -> t.Callable:
     """
     Add the ``delete_all`` option to a click command.

--- a/foundrytools_cli_2/cli/shared_options.py
+++ b/foundrytools_cli_2/cli/shared_options.py
@@ -322,3 +322,45 @@ def min_area_option() -> t.Callable:
         )
     ]
     return add_options(_min_area_option)
+
+
+def old_string() -> t.Callable:
+    """
+    Add the ``old_string`` option to a click command.
+
+    Returns:
+        t.Callable: A decorator that adds the old_string option to a click command
+    """
+    _old_string_option = [
+        click.option(
+            "-os",
+            "--old-string",
+            type=str,
+            required=True,
+            help="""
+            Specify the string to be replaced.
+            """,
+        )
+    ]
+    return add_options(_old_string_option)
+
+
+def new_string() -> t.Callable:
+    """
+    Add the ``new_string`` option to a click command.
+
+    Returns:
+        t.Callable: A decorator that adds the new_string option to a click command
+    """
+    _new_string_option = [
+        click.option(
+            "-ns",
+            "--new-string",
+            type=str,
+            required=True,
+            help="""
+            Specify the string to replace the old string with.
+            """,
+        )
+    ]
+    return add_options(_new_string_option)


### PR DESCRIPTION
Moved `old_string` and `new_string` option definitions from `name/options.py` to `shared_options.py` for better code organization and reuse. Updated `name/cli.py` to import these options from `shared_options`.