### PR TITLE
Refactor TOP_DICT_NAMES to constants module

### DIFF
--- a/foundrytools_cli_2/cli/cff/options.py
+++ b/foundrytools_cli_2/cli/cff/options.py
@@ -3,16 +3,7 @@ import typing as t
 import click
 
 from foundrytools_cli_2.cli.shared_options import add_options
-
-TOP_DICT_NAMES = {
-    "full-name": "FullName",
-    "family-name": "FamilyName",
-    "weight": "Weight",
-    "version": "version",
-    "notice": "Notice",
-    "copyright": "Copyright",
-    "unique-id": "UniqueID",
-}
+from foundrytools_cli_2.lib.constants import TOP_DICT_NAMES
 
 
 def font_names_option() -> t.Callable:

--- a/foundrytools_cli_2/lib/constants.py
+++ b/foundrytools_cli_2/lib/constants.py
@@ -74,3 +74,13 @@ class NameIds(IntEnum):
     LIGHT_BACKGROUND_PALETTE = 23
     DARK_BACKGROUND_PALETTE = 24
     VARIATIONS_POSTSCRIPT_NAME_PREFIX = 25
+
+
+TOP_DICT_NAMES = {
+    "full-name": "FullName",
+    "family-name": "FamilyName",
+    "weight": "Weight",
+    "version": "version",
+    "notice": "Notice",
+    "copyright": "Copyright",
+}


### PR DESCRIPTION
Move the TOP_DICT_NAMES dictionary from options.py to constants.py.