### PR TITLE
Add font renaming utility

### DIFF
--- a/foundrytools_cli_2/__main__.py
+++ b/foundrytools_cli_2/__main__.py
@@ -10,6 +10,7 @@ from foundrytools_cli_2.cli.os_2 import cli as os_2
 from foundrytools_cli_2.cli.otf import cli as otf
 from foundrytools_cli_2.cli.post import cli as post
 from foundrytools_cli_2.cli.ttf import cli as ttf
+from foundrytools_cli_2.cli.utils import cli as utils
 
 
 @click.group(
@@ -25,7 +26,8 @@ from foundrytools_cli_2.cli.ttf import cli as ttf
         "otf": otf,
         "post": post,
         "ttf": ttf,
-    }
+        "utils": utils,
+    },
 )
 @click.version_option()
 def cli() -> None:  # pylint: disable=missing-function-docstring

--- a/foundrytools_cli_2/cli/utils/__init__.py
+++ b/foundrytools_cli_2/cli/utils/__init__.py
@@ -1,0 +1,3 @@
+from foundrytools_cli_2.cli.utils.cli import cli
+
+__all__ = ["cli"]

--- a/foundrytools_cli_2/cli/utils/cli.py
+++ b/foundrytools_cli_2/cli/utils/cli.py
@@ -1,0 +1,25 @@
+# pylint: disable=import-outside-toplevel
+import typing as t
+from pathlib import Path
+
+import click
+
+from foundrytools_cli_2.cli.shared_options import base_options
+from foundrytools_cli_2.cli.task_runner import TaskRunner
+from foundrytools_cli_2.cli.utils.options import rename_source_option
+
+cli = click.Group(help="Miscellaneous utilities.")
+
+
+@cli.command("font-renamer")
+@rename_source_option()
+@base_options()
+def font_renamer(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+    """
+    Renames the given font files.
+    """
+    from foundrytools_cli_2.cli.utils.snippets.font_renamer import main as task
+
+    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner.save_if_modified = False
+    runner.run()

--- a/foundrytools_cli_2/cli/utils/options.py
+++ b/foundrytools_cli_2/cli/utils/options.py
@@ -1,0 +1,38 @@
+import typing as t
+
+import click
+
+from foundrytools_cli_2.cli.shared_callbacks import choice_to_int_callback
+from foundrytools_cli_2.cli.shared_options import add_options
+
+
+def rename_source_option() -> t.Callable:
+    """
+    Returns a decorator that adds the --rename-source option to a click command. The option is a
+    flag that can be used to rename the source of a font file.
+
+    Returns:
+        click.option: The decorator to add the option to a click command
+    """
+    _rename_source_option = [
+        click.option(
+            "-s",
+            "--source",
+            type=click.Choice(choices=["1", "2", "3", "4", "5"]),
+            default="1",
+            callback=choice_to_int_callback,
+            help="""
+        The source string(s) from which to extract the new file name. Default is 1
+        (FamilyName-StyleName), used also as fallback name when 4 or 5 are passed but the font
+        is TrueType
+        
+        \b
+        1: FamilyName-StyleName
+        2: PostScript Name
+        3: Full Font Name
+        4: CFF TopDict fontNames (CFF fonts only)
+        5: CFF TopDict FullName (CFF fonts only)
+        """,
+        )
+    ]
+    return add_options(_rename_source_option)

--- a/foundrytools_cli_2/cli/utils/options.py
+++ b/foundrytools_cli_2/cli/utils/options.py
@@ -25,7 +25,7 @@ def rename_source_option() -> t.Callable:
         The source string(s) from which to extract the new file name. Default is 1
         (FamilyName-StyleName), used also as fallback name when 4 or 5 are passed but the font
         is TrueType
-        
+
         \b
         1: FamilyName-StyleName
         2: PostScript Name

--- a/foundrytools_cli_2/cli/utils/snippets/font_renamer.py
+++ b/foundrytools_cli_2/cli/utils/snippets/font_renamer.py
@@ -1,0 +1,29 @@
+from foundrytools_cli_2.cli.logger import logger
+from foundrytools_cli_2.lib.font import Font
+
+
+def main(font: Font, source: int = 1, overwrite: bool = False) -> None:
+    """
+    Renames the given font files.
+    """
+    if font.file is None:
+        raise AttributeError("Font file is None")
+    old_file = font.file
+    if source in (4, 5) and font.is_tt:
+        logger.warning(
+            f"source=4 and source=5 can be used for OTF files only. Using source=1 for "
+            f"{old_file.name}"
+        )
+    new_file = font.make_out_file_name(
+        file=font.get_best_file_name(source=source),
+        extension=font.get_real_extension(),
+        output_dir=old_file.parent,
+        overwrite=overwrite,
+    )
+    if new_file == old_file:
+        logger.skip(f"{old_file.name} is already named correctly")  # type: ignore
+        return
+    old_file.rename(new_file)
+    logger.opt(colors=True).info(
+        f"<light-black>{old_file.name}</> --> " f"<bold><magenta>{new_file.name}</></>"
+    )


### PR DESCRIPTION
Implemented a new utility to rename font files based on various naming conventions. Added support for multiple naming sources and integrated a Click command for ease of use via the CLI. Enhanced the `font.py` with necessary methods and ensured clean filename handling via sanitization.