### PR TITLE
Add fs-selection fix command

### DIFF
--- a/foundrytools_cli_2/cli/fix/cli.py
+++ b/foundrytools_cli_2/cli/fix/cli.py
@@ -55,6 +55,26 @@ def fix_empty_notdef(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     runner.run()
 
 
+@cli.command("fs-selection")
+@base_options()
+def fix_fs_selection(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+    """
+    fontbakery check id: com.google.fonts/check/fsselection>
+
+    The ``OS/2.fsSelection`` field is a bit field used to specify the stylistic qualities of the
+    font - in particular, it specifies to some operating systems whether the font is italic (bit 0),
+    bold (bit 5) or regular (bit 6).
+
+    This fix verifies that the ``fsSelection`` field is set correctly for the font style. If the
+    font is not bold or italic, the regular bit is set. If the font is bold or italic, the regular
+    bit is cleared.
+    """
+    from foundrytools_cli_2.cli.fix.snippets.fs_selection import main as task
+
+    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner.run()
+
+
 @cli.command("kern-table")
 @base_options()
 def fix_kern_table(input_path: Path, **options: t.Dict[str, t.Any]) -> None:

--- a/foundrytools_cli_2/cli/fix/snippets/fs_selection.py
+++ b/foundrytools_cli_2/cli/fix/snippets/fs_selection.py
@@ -1,0 +1,21 @@
+from foundrytools_cli_2.lib.font import Font
+
+
+def main(font: Font) -> None:
+    """
+    Fix the regular flag of a font. If the font is not bold or italic, it will be set to regular. If
+    the font is bold or italic, it will be set to not regular.
+
+    Args:
+        font (Font): The font to fix.
+    """
+
+    # If the font is not bold or italic, set it to regular
+    if not (font.is_bold or font.is_italic or font.is_regular):
+        font.is_regular = True
+        font.modified = True
+
+    # If the font is bold or italic, set it to not regular
+    elif (font.is_bold or font.is_italic) and font.is_regular:
+        font.is_regular = False
+        font.modified = True


### PR DESCRIPTION
Introduce `fs-selection` command to correct the OS/2.fsSelection field. Ensure the field is appropriately set for font styles, marking regular fonts and unmarking bold or italic fonts accordingly.