### PR TITLE
Remove ps_correct_contours call from add_extremes script

### DIFF
--- a/foundrytools_cli_2/cli/otf/snippets/add_extremes.py
+++ b/foundrytools_cli_2/cli/otf/snippets/add_extremes.py
@@ -16,7 +16,6 @@ def main(font: Font, subroutinize: bool = True) -> None:
     charstrings = add_extremes(font.ttfont)
     logger.info("Rebuilding OTF")
     build_otf(font=font.ttfont, charstrings_dict=charstrings)
-    font.ps_correct_contours()
     if subroutinize:
         logger.info("Subroutinizing")
         font.ps_subroutinize()


### PR DESCRIPTION
This commit removes the unnecessary `ps_correct_contours` method call within the `add_extremes.py` script. For some reason, all PrivateDict entries are deleted if the contours correction is performed.