### PR TITLE
Add font reload and correct contours in add_extremes

### DIFF
--- a/foundrytools_cli_2/cli/otf/snippets/add_extremes.py
+++ b/foundrytools_cli_2/cli/otf/snippets/add_extremes.py
@@ -16,6 +16,9 @@ def main(font: Font, subroutinize: bool = True) -> None:
     charstrings = add_extremes(font.ttfont)
     logger.info("Rebuilding OTF")
     build_otf(font=font.ttfont, charstrings_dict=charstrings)
+    # Reload the font, otherwise the CFF top dict entries will be deleted
+    font.reload()
+    font.ps_correct_contours()
     if subroutinize:
         logger.info("Subroutinizing")
         font.ps_subroutinize()


### PR DESCRIPTION
Reload the font and correct contours after rebuilding OTF to prevent CFF top dict entries from being deleted.