### PR TITLE
Disable pylint warning for too many lines in module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,7 @@
 [MASTER]
 disable =
     C0114, # Missing module docstring
+    C0302, # Too many lines in module
     R0801, # Similar lines in %s files
     R0913, # Too many arguments
     R0914, # Too many local variables

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import math
 import typing as t
 from io import BytesIO


### PR DESCRIPTION
Removed pylint inline directive and moved disabling of the "too many lines" warning to .pylintrc configuration file.