### PR TITLE
Replace calls to `ttfont.getGlyphSet()` with `Font.glyph_set` property

### DIFF
--- a/foundrytools_cli_2/cli/otf/snippets/round_coordinates.py
+++ b/foundrytools_cli_2/cli/otf/snippets/round_coordinates.py
@@ -15,7 +15,7 @@ def main(font: Font, subroutinize: bool = True) -> None:
         subroutinize (bool): Whether to subroutinize the font.
     """
 
-    glyph_set = font.ttfont.getGlyphSet()
+    glyph_set = font.glyph_set
     cff = CFFTable(font.ttfont)
     private = cff.top_dict.Private
 

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -755,7 +755,7 @@ class Font:  # pylint: disable=too-many-public-methods
         Raises:
             ValueError: If the font does not contain the glyph 'H' or 'uni0048'.
         """
-        glyph_set = self.ttfont.getGlyphSet()
+        glyph_set = self.glyph_set
         pen = StatisticsPen(glyphset=glyph_set)
         for g in ("H", "uni0048"):
             try:
@@ -775,7 +775,7 @@ class Font:  # pylint: disable=too-many-public-methods
         if not self.is_tt:
             raise NotImplementedError("Decomponentization is only supported for TrueType fonts.")
 
-        glyph_set = self.ttfont.getGlyphSet()
+        glyph_set = self.glyph_set
         glyf_table = self.ttfont[T_GLYF]
         dr_pen = DecomposingRecordingPen(glyph_set)
         tt_pen = TTGlyphPen(None)


### PR DESCRIPTION
This pull request includes changes to streamline the handling of glyph sets in the `foundrytools_cli_2` project. The changes primarily focus on replacing the usage of `font.ttfont.getGlyphSet()` with `font.glyph_set` to simplify the codebase and improve consistency.

Codebase simplification:

* [`foundrytools_cli_2/cli/otf/snippets/round_coordinates.py`](diffhunk://#diff-dbfea07237badf708a2beae5fdb3bc4b3cf96fc4d77e430f2304db1b84c5fff2L18-R18): Modified the `main` function to use `font.glyph_set` instead of `font.ttfont.getGlyphSet()`.
* [`foundrytools_cli_2/lib/font/font.py`](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465L758-R758): Updated the `calculate_italic_angle` method to use `self.glyph_set` instead of `self.ttfont.getGlyphSet()`.
* [`foundrytools_cli_2/lib/font/font.py`](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465L778-R778): Updated the `tt_decomponentize` method to use `self.glyph_set` instead of `self.ttfont.getGlyphSet()`.