### PR TITLE
Add support for printing font names

### DIFF
--- a/foundrytools_cli_2/__main__.py
+++ b/foundrytools_cli_2/__main__.py
@@ -9,6 +9,7 @@ from foundrytools_cli_2.cli.name import cli as name
 from foundrytools_cli_2.cli.os_2 import cli as os_2
 from foundrytools_cli_2.cli.otf import cli as otf
 from foundrytools_cli_2.cli.post import cli as post
+from foundrytools_cli_2.cli.print import cli as print_
 from foundrytools_cli_2.cli.ttf import cli as ttf
 from foundrytools_cli_2.cli.utils import cli as utils
 
@@ -25,6 +26,7 @@ from foundrytools_cli_2.cli.utils import cli as utils
         "os2": os_2,
         "otf": otf,
         "post": post,
+        "print": print_,
         "ttf": ttf,
         "utils": utils,
     },

--- a/foundrytools_cli_2/cli/print/__init__.py
+++ b/foundrytools_cli_2/cli/print/__init__.py
@@ -1,0 +1,3 @@
+from foundrytools_cli_2.cli.print.cli import cli
+
+__all__ = ["cli"]

--- a/foundrytools_cli_2/cli/print/cli.py
+++ b/foundrytools_cli_2/cli/print/cli.py
@@ -1,0 +1,40 @@
+# pylint: disable=import-outside-toplevel
+
+import typing as t
+from pathlib import Path
+
+import click
+
+from foundrytools_cli_2.cli.font_finder import FinderOptions, FontFinder
+from foundrytools_cli_2.cli.shared_options import input_path_argument
+
+cli = click.Group(help="Prints various font's information.")
+
+
+@cli.command("names")
+@input_path_argument()
+@click.option(
+    "-ml",
+    "--max-lines",
+    type=click.IntRange(min=1),
+    help="Maximum number of lines to print for each NameRecord",
+)
+@click.option(
+    "-min",
+    "--minimal",
+    is_flag=True,
+    help="""
+    Prints a minimal set of NameRecords, omitting the ones with nameID not in 1, 2, 3, 4, 5, 6, 16,
+    17, 18, 21, 22, 25""",
+)
+def print_font_names(
+    input_path: Path, max_lines: t.Optional[int] = None, minimal: bool = False
+) -> None:
+    """
+    Prints the name table.
+    """
+    from foundrytools_cli_2.cli.print.snippets.print_names import main as print_names
+
+    finder = FontFinder(input_path, options=FinderOptions())
+    for font in finder.generate_fonts():
+        print_names(font, max_lines=max_lines, minimal=minimal)

--- a/foundrytools_cli_2/cli/print/snippets/print_names.py
+++ b/foundrytools_cli_2/cli/print/snippets/print_names.py
@@ -16,7 +16,6 @@ from foundrytools_cli_2.lib.font import Font
 from foundrytools_cli_2.lib.font.tables import CFFTable, NameTable
 from foundrytools_cli_2.lib.utils.string_tools import wrap_string
 
-
 __all__ = ["main"]
 
 

--- a/foundrytools_cli_2/cli/print/snippets/print_names.py
+++ b/foundrytools_cli_2/cli/print/snippets/print_names.py
@@ -1,0 +1,133 @@
+import typing as t
+from shutil import get_terminal_size
+
+from fontTools.ttLib.tables._n_a_m_e import _MAC_LANGUAGES, _WINDOWS_LANGUAGES, NameRecord
+from rich.console import Console
+from rich.table import Table
+
+from foundrytools_cli_2.lib.constants import (
+    MAC_ENCODING_IDS,
+    NAME_IDS_TO_DESCRIPTION,
+    PLATFORMS,
+    TERMINAL_WIDTH,
+    WINDOWS_ENCODING_IDS,
+)
+from foundrytools_cli_2.lib.font import Font
+from foundrytools_cli_2.lib.font.tables import CFFTable, NameTable
+from foundrytools_cli_2.lib.utils.string_tools import wrap_string
+
+MINIMAL_NAME_IDS = {1, 2, 3, 4, 5, 6, 16, 17, 18, 21, 22, 25}
+MINIMAL_CFF_NAMES = {"version", "FullName", "FamilyName", "Weight"}
+IGNORED_CFF_NAMES = {
+    "UnderlinePosition",
+    "UnderlineThickness",
+    "FontMatrix",
+    "FontBBox",
+    "charset",
+    "Encoding",
+    "Private",
+    "CharStrings",
+    "isFixedPitch",
+    "ItalicAngle",
+}
+
+
+def _get_platform_row(platform: t.Tuple[int, int, int]) -> str:
+    """
+    Returns a string that describes the platform, encoding, and language.
+    """
+    platform_id = platform[0]
+    plat_enc_id = platform[1]
+    language_id = platform[2]
+    platform_string = PLATFORMS.get(platform[0])
+    if platform_id == 1:
+        plat_enc_string = MAC_ENCODING_IDS.get(plat_enc_id)
+        language_string = _MAC_LANGUAGES.get(language_id)
+    elif platform_id == 3:
+        plat_enc_string = WINDOWS_ENCODING_IDS.get(plat_enc_id)
+        language_string = _WINDOWS_LANGUAGES.get(language_id)
+    else:
+        plat_enc_string = f"Unknown ({plat_enc_id})"
+        language_string = f"Unknown ({language_id})"
+
+    return (
+        f"[bold green]PlatformID: {platform_id} ({platform_string}), PlatEncID: {plat_enc_id} "
+        f"({plat_enc_string}), LangID: {language_id} ({language_string})[reset]"
+    )
+
+
+def _get_name_row(name: NameRecord) -> str:
+    """
+    Returns a string that describes a NameRecord.
+    """
+    name_description = NAME_IDS_TO_DESCRIPTION.get(name.nameID, f"{name.nameID}")
+    return (
+        f"[bold cyan]{str(name.nameID).rjust(5)}[reset] : "
+        f"{name_description.ljust(22)} : {name.toUnicode()}"
+    )
+
+
+def main(font: Font, max_lines: t.Optional[int] = None, minimal: bool = False) -> None:
+    """
+    Prints the names of the font.
+    """
+
+    terminal_width = min(TERMINAL_WIDTH, get_terminal_size()[0] - 1)
+    console = Console()
+    table = Table(show_header=False, title_style="bold green")
+
+    name_table = NameTable(font.ttfont)
+    names = name_table.names
+
+    table.add_row(f"[bold cyan]Font file: {font.file.name if font.file else font.bytesio}[reset]")
+    table.add_section()
+
+    table.add_row("[bold magenta]'name' table[reset]")
+    platforms = {(name.platformID, name.platEncID, name.langID) for name in names}
+    for platform in platforms:
+        platform_row = _get_platform_row(platform)
+
+        table.add_section()
+        table.add_row(platform_row)
+        table.add_section()
+
+        for name in names:
+            if (name.platformID, name.platEncID, name.langID) == platform:
+                if minimal and name.nameID not in MINIMAL_NAME_IDS:
+                    continue
+                row_string = _get_name_row(name)
+                row_string = wrap_string(
+                    width=terminal_width,
+                    initial_indent=0,
+                    indent=33,
+                    max_lines=max_lines,
+                    string=row_string,
+                )
+                table.add_row(row_string)
+
+    if font.is_ps:
+        cff_table = CFFTable(font.ttfont)
+
+        cff_names = [
+            {k: v}
+            for k, v in cff_table.top_dict.rawDict.items()
+            if k not in IGNORED_CFF_NAMES and (not minimal or k in MINIMAL_CFF_NAMES)
+        ]
+        cff_names.insert(0, {"fontNames": cff_table.table.cff.fontNames})
+
+        table.add_section()
+        table.add_row("[bold magenta]'CFF ' table[reset]")
+        table.add_section()
+        for cff_name in cff_names:
+            for key, value in cff_name.items():
+                row_string = f"{key.ljust(22)} : {value}"
+                row_string = wrap_string(
+                    width=terminal_width,
+                    initial_indent=8,
+                    indent=33,
+                    max_lines=max_lines,
+                    string=row_string,
+                )
+                table.add_row(row_string)
+
+    console.print(table)

--- a/foundrytools_cli_2/lib/constants.py
+++ b/foundrytools_cli_2/lib/constants.py
@@ -76,6 +76,36 @@ class NameIds(IntEnum):
     VARIATIONS_POSTSCRIPT_NAME_PREFIX = 25
 
 
+NAME_IDS_TO_DESCRIPTION = {
+    0: "Copyright Notice",
+    1: "Family name",
+    2: "Subfamily name",
+    3: "Unique identifier",
+    4: "Full font name",
+    5: "Version string",
+    6: "PostScript name",
+    7: "Trademark",
+    8: "Manufacturer Name",
+    9: "Designer",
+    10: "Description",
+    11: "URL Vendor",
+    12: "URL Designer",
+    13: "License Description",
+    14: "License Info URL",
+    15: "Reserved",
+    16: "Typographic Family",
+    17: "Typographic Subfamily",
+    18: "Compatible Full (Mac)",
+    19: "Sample text",
+    20: "PS CID font name",
+    21: "WWS Family Name",
+    22: "WWS Subfamily Name",
+    23: "Light Background Palette",
+    24: "Dark Background Palette",
+    25: "Variations PSName Pref",
+}
+
+
 TOP_DICT_NAMES = {
     "full-name": "FullName",
     "family-name": "FamilyName",
@@ -84,3 +114,67 @@ TOP_DICT_NAMES = {
     "notice": "Notice",
     "copyright": "Copyright",
 }
+
+
+PLATFORMS = {
+    0: "Unicode",
+    1: "Macintosh",
+    2: "ISO (deprecated)",
+    3: "Windows",
+    4: "Custom",
+}
+
+
+MAC_ENCODING_IDS = {
+    0: "Roman",
+    1: "Japanese",
+    2: "Chinese (Traditional)",
+    3: "Korean",
+    4: "Arabic",
+    5: "Hebrew",
+    6: "Greek",
+    7: "Russian",
+    8: "RSymbol",
+    9: "Devanagari",
+    10: "Gurmukhi",
+    11: "Gujarati",
+    12: "Oriya",
+    13: "Bengali",
+    14: "Tamil",
+    15: "Telugu",
+    16: "Kannada",
+    17: "Malayalam",
+    18: "Sinhalese",
+    19: "Burmese",
+    20: "Khmer",
+    21: "Thai",
+    22: "Laotian",
+    23: "Georgian",
+    24: "Armenian",
+    25: "Chinese (Simplified)",
+    26: "Tibetan",
+    27: "Mongolian",
+    28: "Geez",
+    29: "Slavic",
+    30: "Vietnamese",
+    31: "Sindhi",
+    32: "Uninterpreted",
+}
+
+
+WINDOWS_ENCODING_IDS = {
+    0: "Symbol",
+    1: "Unicode",
+    2: "ShiftJIS",
+    3: "PRC",
+    4: "Big5",
+    5: "Wansung",
+    6: "Johab",
+    7: "Reserved",
+    8: "Reserved",
+    9: "Reserved",
+    10: "UCS4",
+}
+
+
+TERMINAL_WIDTH = 120

--- a/foundrytools_cli_2/lib/font/tables/name.py
+++ b/foundrytools_cli_2/lib/font/tables/name.py
@@ -19,6 +19,13 @@ class NameTable(DefaultTbl):
         """
         super().__init__(ttfont=ttfont, table_tag=T_NAME)
 
+    @property
+    def names(self) -> t.List[NameRecord]:
+        """
+        Returns the NameRecords from the ``name`` table.
+        """
+        return self.table.names
+
     def get_debug_name(self, name_id: int) -> str:
         """
         Returns the name of the NameID for debugging purposes.

--- a/foundrytools_cli_2/lib/utils/string_tools.py
+++ b/foundrytools_cli_2/lib/utils/string_tools.py
@@ -1,3 +1,7 @@
+import typing as t
+from textwrap import TextWrapper
+
+
 def adjust_string_length(string: str, length: int, pad_char: str = " ") -> str:
     """
     Adjust the string to a specified length by padding or truncating it.
@@ -11,3 +15,28 @@ def adjust_string_length(string: str, length: int, pad_char: str = " ") -> str:
         str: The adjusted string.
     """
     return string.ljust(length, pad_char) if len(string) < length else string[:length]
+
+
+def wrap_string(
+    string: str, width: int, initial_indent: int, indent: int, max_lines: t.Optional[int] = None
+) -> str:
+    """
+    Wraps a string to a given width, with a given indentation
+
+    Args:
+        string (str): The string to wrap
+        width (int): The maximum width of the wrapped lines
+        initial_indent (int): The number of spaces to add to the beginning of each line
+        indent (int): The number of spaces to add to the left margin of subsequent lines
+        max_lines (Optional[int]): The maximum number of lines to return. If the string is longer
+        than this, it will be truncated
+    """
+    wrapped_string = TextWrapper(
+        width=width,
+        initial_indent=" " * initial_indent,
+        subsequent_indent=" " * indent,
+        max_lines=max_lines,
+        break_on_hyphens=False,
+        break_long_words=True,
+    ).fill(string)
+    return wrapped_string


### PR DESCRIPTION
This pull request introduces a new CLI command for printing font information and includes several related changes. The most important changes include adding the new `print` command, implementing the command's functionality, and updating the necessary constants and utility functions.

### New CLI Command:
* [`foundrytools_cli_2/__main__.py`](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR12): Added the `print` command to the CLI commands list and imported it. [[1]](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR12) [[2]](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR29)
* [`foundrytools_cli_2/cli/print/__init__.py`](diffhunk://#diff-872ad631df401616fc62cd9fbed0f45db14011a527b8eaef85650f9b4e65c447R1-R3): Created an `__init__.py` file to expose the `print` command.

### Command Implementation:
* [`foundrytools_cli_2/cli/print/cli.py`](diffhunk://#diff-95dfacf49fb99f90870fcd180903f0c9035d1020ba0ee5d1559096ec462e28d8R1-R40): Implemented the `print` command with subcommands for printing font names and added options for maximum lines and minimal output.
* [`foundrytools_cli_2/cli/print/snippets/print_names.py`](diffhunk://#diff-bbc68f937ec9fb2155039186e117670d7dfabbf187094bff4eda43430d12bef9R1-R154): Added the main logic for printing font names, including handling different name tables and wrapping text for terminal output.

### Constants and Utility Functions:
* [`foundrytools_cli_2/lib/constants.py`](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR79-R108): Added constants for name IDs, platforms, and encoding IDs. [[1]](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR79-R108) [[2]](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR117-R180)
* [`foundrytools_cli_2/lib/font/tables/name.py`](diffhunk://#diff-e1bee64ee5a06e062597a8cca271a51895468263a6041846cfff079928324332R22-R28): Added a property to retrieve name records from the name table.
* [`foundrytools_cli_2/lib/utils/string_tools.py`](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R1-R4): Added a `wrap_string` function to handle text wrapping with indentation and line limits. [[1]](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R1-R4) [[2]](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R18-R42)This pull request introduces a new `print` command to the `foundrytools_cli_2` package, which allows users to print various font information. The most important changes include the addition of the `print` command, the implementation of the `print_font_names` function, and the necessary supporting code to handle font name records and terminal output formatting.

### New `print` Command and Functionality:

* [`foundrytools_cli_2/__main__.py`](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR12): Added the `print` command to the CLI tool and registered it in the command dictionary. [[1]](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR12) [[2]](diffhunk://#diff-97ddf7ef3d3f5858626336dd5f531492a98563de8914404477a699beec0488abR29)
* [`foundrytools_cli_2/cli/print/__init__.py`](diffhunk://#diff-872ad631df401616fc62cd9fbed0f45db14011a527b8eaef85650f9b4e65c447R1-R3): Imported the `cli` object and added it to `__all__`.
* [`foundrytools_cli_2/cli/print/cli.py`](diffhunk://#diff-95dfacf49fb99f90870fcd180903f0c9035d1020ba0ee5d1559096ec462e28d8R1-R40): Implemented the `print_font_names` function, which prints the name table of fonts, with options for maximum lines and minimal output.

### Supporting Code for Font Name Records:

* [`foundrytools_cli_2/cli/print/snippets/print_names.py`](diffhunk://#diff-bbc68f937ec9fb2155039186e117670d7dfabbf187094bff4eda43430d12bef9R1-R133): Added functions to format and print the font name records, including handling different platforms and encoding IDs.
* [`foundrytools_cli_2/lib/constants.py`](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR79-R108): Added constants for name IDs, platforms, and encoding IDs to support the `print` command. [[1]](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR79-R108) [[2]](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR117-R180)
* [`foundrytools_cli_2/lib/font/tables/name.py`](diffhunk://#diff-e1bee64ee5a06e062597a8cca271a51895468263a6041846cfff079928324332R22-R28): Added a `names` property to retrieve NameRecords from the `name` table.

### Utility Functions:

* [`foundrytools_cli_2/lib/utils/string_tools.py`](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R1-R4): Added a `wrap_string` function to handle text wrapping for terminal output. [[1]](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R1-R4) [[2]](diffhunk://#diff-65d0b35c0d4469937fb177d8fc37b0d6a3cdf4b170145b12660c285f777ad615R18-R42)