### PR TITLE
Simplify FontFinder initialization

### DIFF
--- a/foundrytools_cli_2/cli/fix/cli.py
+++ b/foundrytools_cli_2/cli/fix/cli.py
@@ -414,10 +414,9 @@ def fix_vertical_metrics(input_path: Path, **options: t.Dict[str, t.Any]) -> Non
     Raises:
         ClickException: If no fonts are found in the specified path.
     """
-    from foundrytools_cli_2.cli.font_finder import FinderOptions, FontFinder
+    from foundrytools_cli_2.cli.font_finder import FontFinder
 
-    finder_options = FinderOptions()
-    fonts = FontFinder(input_path, options=finder_options).find_fonts()
+    fonts = FontFinder(input_path).find_fonts()
     if not fonts:
         raise click.ClickException("No fonts found.")
 

--- a/foundrytools_cli_2/cli/font_finder.py
+++ b/foundrytools_cli_2/cli/font_finder.py
@@ -57,7 +57,7 @@ class FontFinder:
     def __init__(
         self,
         input_path: Path,
-        options: FinderOptions,
+        options: t.Optional[FinderOptions] = None,
         filter_: t.Optional[FinderFilter] = None,
     ) -> None:
         """Initialize the FontFinder class.
@@ -72,7 +72,6 @@ class FontFinder:
             FontFinderError: If the input path is invalid.
         """
         self.input_path = input_path
-        self.options = options
 
         try:
             self.input_path = Path(self.input_path).resolve(strict=True)
@@ -80,6 +79,7 @@ class FontFinder:
             raise FinderError(f"Invalid input path: {self.input_path}") from e
 
         self.filter = filter_ or FinderFilter()
+        self.options = options or FinderOptions()
         self._filter_conditions = self._generate_filter_conditions(self.filter)
         self._validate_filter_conditions()
 

--- a/foundrytools_cli_2/cli/print/cli.py
+++ b/foundrytools_cli_2/cli/print/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import click
 
-from foundrytools_cli_2.cli.font_finder import FinderOptions, FontFinder
+from foundrytools_cli_2.cli.font_finder import FontFinder
 from foundrytools_cli_2.cli.shared_options import input_path_argument
 
 cli = click.Group(help="Prints various font's information.")
@@ -35,6 +35,6 @@ def print_font_names(
     """
     from foundrytools_cli_2.cli.print.snippets.print_names import main as print_names
 
-    finder = FontFinder(input_path, options=FinderOptions())
+    finder = FontFinder(input_path)
     for font in finder.generate_fonts():
         print_names(font, max_lines=max_lines, minimal=minimal)


### PR DESCRIPTION
This pull request focuses on refactoring the `FontFinder` class and its usage to simplify the instantiation process by making the `options` parameter optional. The most important changes include modifying the `FontFinder` class constructor and updating the related functions that instantiate `FontFinder`.

### Refactoring `FontFinder` class:

* [`foundrytools_cli_2/cli/font_finder.py`](diffhunk://#diff-9627c7d0a45c40e4aeefbc301aace64638547119c0592f4f48c5deac315bdb48L60-R60): Modified the `FontFinder` class constructor to make the `options` parameter optional, and updated the initialization logic to handle the default value. [[1]](diffhunk://#diff-9627c7d0a45c40e4aeefbc301aace64638547119c0592f4f48c5deac315bdb48L60-R60) [[2]](diffhunk://#diff-9627c7d0a45c40e4aeefbc301aace64638547119c0592f4f48c5deac315bdb48L75-R82)

### Updating related functions:

* [`foundrytools_cli_2/cli/fix/cli.py`](diffhunk://#diff-ee567159f5ee502ec31827dc4d42ffbdc52b5e5e0b6343b7a0fb3ad1b211df68L417-R419): Removed the import of `FinderOptions` and updated the `fix_vertical_metrics` function to instantiate `FontFinder` without passing `FinderOptions`.
* [`foundrytools_cli_2/cli/print/cli.py`](diffhunk://#diff-95dfacf49fb99f90870fcd180903f0c9035d1020ba0ee5d1559096ec462e28d8L8-R8): Removed the import of `FinderOptions` and updated the `print_font_names` function to instantiate `FontFinder` without passing `FinderOptions`. [[1]](diffhunk://#diff-95dfacf49fb99f90870fcd180903f0c9035d1020ba0ee5d1559096ec462e28d8L8-R8) [[2]](diffhunk://#diff-95dfacf49fb99f90870fcd180903f0c9035d1020ba0ee5d1559096ec462e28d8L38-R38)Updated the FontFinder class to make the FinderOptions parameter optional and provide a default value if none is given. Adjusted related code in the print and fix CLI modules to reflect this change, enhancing code readability and robustness.