### PR TITLE
Handle general exceptions during module import

### DIFF
--- a/foundrytools_cli_2/cli/utils/snippets/sync_timestamps.py
+++ b/foundrytools_cli_2/cli/utils/snippets/sync_timestamps.py
@@ -20,7 +20,7 @@ if platform.system() == "Windows":
         from win32_setctime import setctime
 
         SETCTIME = setctime
-    except ImportError as exc:
+    except (ImportError, Exception) as exc:  # pylint: disable=broad-except
         SETCTIME = None
         IMPORT_ERROR = exc
 


### PR DESCRIPTION
This pull request includes a minor change to the error handling in the `sync_timestamps.py` file. The change broadens the exception handling to catch any exception, not just `ImportError`.

* [`foundrytools_cli_2/cli/utils/snippets/sync_timestamps.py`](diffhunk://#diff-6537e10d03974bae865367f9ba701dfd8c6cf9e507968a19962b09280a3f1b77L23-R23): Modified the `except` block to catch both `ImportError` and any other `Exception`, and added a pylint directive to disable the warning for broad exception handling.