### PR TITLE
Recalc ranges

### DIFF
--- a/foundrytools_cli_2/cli/os_2/cli.py
+++ b/foundrytools_cli_2/cli/os_2/cli.py
@@ -66,16 +66,13 @@ def recalc_max_context(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     runner.run()
 
 
-@cli.command("recalc-ranges")
+@cli.command("recalc-codepage-ranges")
 @base_options()
-def recalc_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_codepage_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     """
-    Recalculates the ulUnicodeRange and ulCodePageRange values of the OS/2 table using AFDKO.
-
-    The font is first converted to T1, then to OTF. The ulUnicodeRange and ulCodePageRange values
-    are then retrieved from the OS/2 table of the OTF font and written to the original font.
+    Recalculates the ulCodePageRange values of the OS/2 table.
     """
-    from foundrytools_cli_2.cli.os_2.snippets import recalc_ranges_afdko as task
+    from foundrytools_cli_2.cli.os_2.snippets import recalc_codepage_ranges as task
 
     runner = TaskRunner(input_path=input_path, task=task, **options)
     runner.run()
@@ -83,10 +80,11 @@ def recalc_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 @cli.command("recalc-unicode-ranges")
 @click.option(
-    "-p", "--percentage",
+    "-p",
+    "--percentage",
     type=click.FloatRange(0.0001, 100),
-    default=33.,
-    help="Minimum percentage of coverage required for a Unicode range to be enabled. Default is 33."
+    default=33.0,
+    help="Minimum percentage of coverage required for a Unicode range to be enabled. Default is 33.",
 )
 @base_options()
 def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
@@ -98,6 +96,7 @@ def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> No
 
     runner = TaskRunner(input_path=input_path, task=task, **options)
     runner.run()
+
 
 @cli.command("set-attrs", no_args_is_help=True)
 @set_attrs_options()

--- a/foundrytools_cli_2/cli/os_2/cli.py
+++ b/foundrytools_cli_2/cli/os_2/cli.py
@@ -84,7 +84,7 @@ def recalc_codepage_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> N
     "--percentage",
     type=click.FloatRange(0.0001, 100),
     default=33.0,
-    help="Minimum percentage of coverage required for a Unicode range to be enabled. Default is 33.",
+    help="Minimum percentage of coverage required for a Unicode range to be enabled.",
 )
 @base_options()
 def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:

--- a/foundrytools_cli_2/lib/font/tables/os_2.py
+++ b/foundrytools_cli_2/lib/font/tables/os_2.py
@@ -620,7 +620,6 @@ class OS2Table(DefaultTbl):  # pylint: disable=too-many-public-methods
         self.unicode_ranges = new_unicode_ranges
         return modified_unicode_ranges
 
-
     def recalc_code_page_ranges(self) -> None:
         """
         Recalculates the code page ranges of the ``OS/2`` table.

--- a/foundrytools_cli_2/lib/utils/unicode_tools.py
+++ b/foundrytools_cli_2/lib/utils/unicode_tools.py
@@ -16,7 +16,6 @@ with open(UNICODES_TO_NAMES_FILE, encoding="utf-8") as f:
     UNICODES_TO_NAMES = json.load(f)
 
 
-
 class UnicodeBlock:  # pylint: disable=too-many-instance-attributes, too-few-public-methods
     """
     A class representing a Unicode block.
@@ -32,6 +31,7 @@ class UnicodeBlock:  # pylint: disable=too-many-instance-attributes, too-few-pub
         is_supported (bool): Whether the block is supported.
         is_enabled (bool): Whether the block is enabled
     """
+
     def __init__(
         self,
         bit_number: int,
@@ -80,12 +80,13 @@ def count_block_codepoints(block: UnicodeBlock, unicodes: t.Set[int]) -> int:
             cp_count += 1
     return cp_count
 
+
 def check_block_support(
-        block: UnicodeBlock,
-        found_codepoints: int,
-        min_codepoints: int,
-        os2_version: int,
-        has_cmap_32: bool,
+    block: UnicodeBlock,
+    found_codepoints: int,
+    min_codepoints: int,
+    os2_version: int,
+    has_cmap_32: bool,
 ) -> bool:
     """
     Check if a Unicode block is supported based on various criteria.
@@ -108,35 +109,58 @@ def check_block_support(
     return is_supported
 
 
-
 OS_2_UNICODE_RANGES = [
     UnicodeBlock(0, 0x0020, 0x007E, "Basic Latin", 0),
     UnicodeBlock(1, 0x0080, 0x00FF, "Latin-1 Supplement", 0),
     UnicodeBlock(2, 0x0100, 0x017F, "Latin Extended-A", 0),
     UnicodeBlock(3, 0x0180, 0x024F, "Latin Extended-B", 0),
-    UnicodeBlock(4, 0x0250, 0x02AF, "IPA Extensions", 0, [
-        UnicodeBlock(4, 0x1D00, 0x1D7F, "Phonetic Extensions", 4),
-        UnicodeBlock(4, 0x1D80, 0x1DBF, "Phonetic Extensions Supplement", 4)
-    ]),
-    UnicodeBlock(5, 0x02B0, 0x02FF, "Spacing Modifier Letters", 0, [
-        UnicodeBlock(5, 0xA700, 0xA71F, "Modifier Tone Letters", 4)
-    ]),
-    UnicodeBlock(6, 0x0300, 0x036F, "Combining Diacritical Marks", 0, [
-        UnicodeBlock(6, 0x1DC0, 0x1DFF, "Combining Diacritical Marks Supplement", 4)
-    ]),
+    UnicodeBlock(
+        4,
+        0x0250,
+        0x02AF,
+        "IPA Extensions",
+        0,
+        [
+            UnicodeBlock(4, 0x1D00, 0x1D7F, "Phonetic Extensions", 4),
+            UnicodeBlock(4, 0x1D80, 0x1DBF, "Phonetic Extensions Supplement", 4),
+        ],
+    ),
+    UnicodeBlock(
+        5,
+        0x02B0,
+        0x02FF,
+        "Spacing Modifier Letters",
+        0,
+        [UnicodeBlock(5, 0xA700, 0xA71F, "Modifier Tone Letters", 4)],
+    ),
+    UnicodeBlock(
+        6,
+        0x0300,
+        0x036F,
+        "Combining Diacritical Marks",
+        0,
+        [UnicodeBlock(6, 0x1DC0, 0x1DFF, "Combining Diacritical Marks Supplement", 4)],
+    ),
     UnicodeBlock(7, 0x0370, 0x03FF, "Greek and Coptic", 0),
     UnicodeBlock(8, 0x2C80, 0x2CFF, "Coptic", 4),
-    UnicodeBlock(9, 0x0400, 0x04FF, "Cyrillic", 0, [
-        UnicodeBlock(9, 0x0500, 0x052F, "Cyrillic Supplement", 3),
-        UnicodeBlock(9, 0x2DE0, 0x2DFF, "Cyrillic Extended-A", 4),
-        UnicodeBlock(9, 0xA640, 0xA69F, "Cyrillic Extended-B", 4)
-    ]),
+    UnicodeBlock(
+        9,
+        0x0400,
+        0x04FF,
+        "Cyrillic",
+        0,
+        [
+            UnicodeBlock(9, 0x0500, 0x052F, "Cyrillic Supplement", 3),
+            UnicodeBlock(9, 0x2DE0, 0x2DFF, "Cyrillic Extended-A", 4),
+            UnicodeBlock(9, 0xA640, 0xA69F, "Cyrillic Extended-B", 4),
+        ],
+    ),
     UnicodeBlock(10, 0x0530, 0x058F, "Armenian", 0),
     UnicodeBlock(11, 0x0590, 0x05FF, "Hebrew", 0),
     UnicodeBlock(12, 0xA500, 0xA63F, "Vai", 4),
-    UnicodeBlock(13, 0x0600, 0x06FF, "Arabic", 0, [
-        UnicodeBlock(13, 0x0750, 0x077F, "Arabic Supplement", 4)
-    ]),
+    UnicodeBlock(
+        13, 0x0600, 0x06FF, "Arabic", 0, [UnicodeBlock(13, 0x0750, 0x077F, "Arabic Supplement", 4)]
+    ),
     UnicodeBlock(14, 0x07C0, 0x07FF, "NKo", 4),
     UnicodeBlock(15, 0x0900, 0x097F, "Devanagari", 0),
     UnicodeBlock(16, 0x0980, 0x09FF, "Bangla", 0),
@@ -149,34 +173,65 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(23, 0x0D00, 0x0D7F, "Malayalam", 0),
     UnicodeBlock(24, 0x0E00, 0x0E7F, "Thai", 0),
     UnicodeBlock(25, 0x0E80, 0x0EFF, "Lao", 0),
-    UnicodeBlock(26, 0x10A0, 0x10FF, "Georgian", 0, [
-        UnicodeBlock(26, 0x2D00, 0x2D2F, "Georgian Supplement", 4)
-    ]),
+    UnicodeBlock(
+        26,
+        0x10A0,
+        0x10FF,
+        "Georgian",
+        0,
+        [UnicodeBlock(26, 0x2D00, 0x2D2F, "Georgian Supplement", 4)],
+    ),
     UnicodeBlock(27, 0x1B00, 0x1B7F, "Balinese", 4),
     UnicodeBlock(28, 0x1100, 0x11FF, "Hangul Jamo", 0),
-    UnicodeBlock(29, 0x1E00, 0x1EFF, "Latin Extended Additional", 0, [
-        UnicodeBlock(29, 0x2C60, 0x2C7F, "Latin Extended-C", 4),
-        UnicodeBlock(29, 0xA720, 0xA7FF, "Latin Extended-D", 4)
-    ]),
+    UnicodeBlock(
+        29,
+        0x1E00,
+        0x1EFF,
+        "Latin Extended Additional",
+        0,
+        [
+            UnicodeBlock(29, 0x2C60, 0x2C7F, "Latin Extended-C", 4),
+            UnicodeBlock(29, 0xA720, 0xA7FF, "Latin Extended-D", 4),
+        ],
+    ),
     UnicodeBlock(30, 0x1F00, 0x1FFF, "Greek Extended", 0),
-    UnicodeBlock(31, 0x2000, 0x206F, "General Punctuation", 0, [
-        UnicodeBlock(31, 0x2E00, 0x2E7F, "Supplemental Punctuation", 4)
-    ]),
+    UnicodeBlock(
+        31,
+        0x2000,
+        0x206F,
+        "General Punctuation",
+        0,
+        [UnicodeBlock(31, 0x2E00, 0x2E7F, "Supplemental Punctuation", 4)],
+    ),
     UnicodeBlock(32, 0x2070, 0x209F, "Superscripts And Subscripts", 0),
     UnicodeBlock(33, 0x20A0, 0x20CF, "Currency Symbols", 0),
     UnicodeBlock(34, 0x20D0, 0x20FF, "Combining Diacritical Marks For Symbols", 0),
     UnicodeBlock(35, 0x2100, 0x214F, "Letterlike Symbols", 0),
     UnicodeBlock(36, 0x2150, 0x218F, "Number Forms", 0),
-    UnicodeBlock(37, 0x2190, 0x21FF, "Arrows", 0, [
-        UnicodeBlock(37, 0x27F0, 0x27FF, "Supplemental Arrows-A", 3),
-        UnicodeBlock(37, 0x2900, 0x297F, "Supplemental Arrows-B", 3),
-        UnicodeBlock(37, 0x2B00, 0x2BFF, "Miscellaneous Symbols and Arrows", 4)
-    ]),
-    UnicodeBlock(38, 0x2200, 0x22FF, "Mathematical Operators", 0, [
-        UnicodeBlock(38, 0x2A00, 0x2AFF, "Supplemental Mathematical Operators", 3),
-        UnicodeBlock(38, 0x27C0, 0x27EF, "Miscellaneous Mathematical Symbols-A", 3),
-        UnicodeBlock(38, 0x2980, 0x29FF, "Miscellaneous Mathematical Symbols-B", 3)
-    ]),
+    UnicodeBlock(
+        37,
+        0x2190,
+        0x21FF,
+        "Arrows",
+        0,
+        [
+            UnicodeBlock(37, 0x27F0, 0x27FF, "Supplemental Arrows-A", 3),
+            UnicodeBlock(37, 0x2900, 0x297F, "Supplemental Arrows-B", 3),
+            UnicodeBlock(37, 0x2B00, 0x2BFF, "Miscellaneous Symbols and Arrows", 4),
+        ],
+    ),
+    UnicodeBlock(
+        38,
+        0x2200,
+        0x22FF,
+        "Mathematical Operators",
+        0,
+        [
+            UnicodeBlock(38, 0x2A00, 0x2AFF, "Supplemental Mathematical Operators", 3),
+            UnicodeBlock(38, 0x27C0, 0x27EF, "Miscellaneous Mathematical Symbols-A", 3),
+            UnicodeBlock(38, 0x2980, 0x29FF, "Miscellaneous Mathematical Symbols-B", 3),
+        ],
+    ),
     UnicodeBlock(39, 0x2300, 0x23FF, "Miscellaneous Technical", 0),
     UnicodeBlock(40, 0x2400, 0x243F, "Control Pictures", 0),
     UnicodeBlock(41, 0x2440, 0x245F, "Optical Character Recognition", 0),
@@ -188,12 +243,22 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(47, 0x2700, 0x27BF, "Dingbats", 0),
     UnicodeBlock(48, 0x3000, 0x303F, "CJK Symbols And Punctuation", 0),
     UnicodeBlock(49, 0x3040, 0x309F, "Hiragana", 0),
-    UnicodeBlock(50, 0x30A0, 0x30FF, "Katakana", 0, [
-        UnicodeBlock(50, 0x31F0, 0x31FF, "Katakana Phonetic Extensions", 3)
-    ]),
-    UnicodeBlock(51, 0x3100, 0x312F, "Bopomofo", 0, [
-        UnicodeBlock(51, 0x31A0, 0x31BF, "Bopomofo Extended", 2)
-    ]),
+    UnicodeBlock(
+        50,
+        0x30A0,
+        0x30FF,
+        "Katakana",
+        0,
+        [UnicodeBlock(50, 0x31F0, 0x31FF, "Katakana Phonetic Extensions", 3)],
+    ),
+    UnicodeBlock(
+        51,
+        0x3100,
+        0x312F,
+        "Bopomofo",
+        0,
+        [UnicodeBlock(51, 0x31A0, 0x31BF, "Bopomofo Extended", 2)],
+    ),
     UnicodeBlock(52, 0x3130, 0x318F, "Hangul Compatibility Jamo", 0),
     UnicodeBlock(53, 0xA840, 0xA87F, "Phags-pa", 4),
     UnicodeBlock(54, 0x3200, 0x32FF, "Enclosed CJK Letters And Months", 0),
@@ -201,25 +266,44 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(56, 0xAC00, 0xD7AF, "Hangul Syllables", 0),
     UnicodeBlock(57, 0x10000, 0x10FFFF, "Non-Plane 0", 2),
     UnicodeBlock(58, 0x10900, 0x1091F, "Phoenician", 4),
-    UnicodeBlock(59, 0x4E00, 0x9FFF, "CJK Unified Ideographs", 0, [
-        UnicodeBlock(59, 0x2E80, 0x2EFF, "CJK Radicals Supplement", 2),
-        UnicodeBlock(59, 0x2F00, 0x2FDF, "Kangxi Radicals", 2),
-        UnicodeBlock(59, 0x2FF0, 0x2FFF, "Ideographic Description Characters", 2),
-        UnicodeBlock(59, 0x3400, 0x4DBF, "CJK Unified Ideographs Extension A", 2),
-        UnicodeBlock(59, 0x20000, 0x2A6DF, "CJK Unified Ideographs Extension B", 3),
-        UnicodeBlock(59, 0x3190, 0x319F, "Kanbun", 3)
-    ]),
+    UnicodeBlock(
+        59,
+        0x4E00,
+        0x9FFF,
+        "CJK Unified Ideographs",
+        0,
+        [
+            UnicodeBlock(59, 0x2E80, 0x2EFF, "CJK Radicals Supplement", 2),
+            UnicodeBlock(59, 0x2F00, 0x2FDF, "Kangxi Radicals", 2),
+            UnicodeBlock(59, 0x2FF0, 0x2FFF, "Ideographic Description Characters", 2),
+            UnicodeBlock(59, 0x3400, 0x4DBF, "CJK Unified Ideographs Extension A", 2),
+            UnicodeBlock(59, 0x20000, 0x2A6DF, "CJK Unified Ideographs Extension B", 3),
+            UnicodeBlock(59, 0x3190, 0x319F, "Kanbun", 3),
+        ],
+    ),
     UnicodeBlock(60, 0xE000, 0xF8FF, "Private Use Area (plane 0)", 0),
-    UnicodeBlock(61, 0x31C0, 0x31EF, "CJK Strokes", 4, [
-        UnicodeBlock(61, 0xF900, 0xFAFF, "CJK Compatibility Ideographs", 0),
-        UnicodeBlock(61, 0x2F800, 0x2FA1F, "CJK Compatibility Ideographs Supplement", 3)
-    ]),
+    UnicodeBlock(
+        61,
+        0x31C0,
+        0x31EF,
+        "CJK Strokes",
+        4,
+        [
+            UnicodeBlock(61, 0xF900, 0xFAFF, "CJK Compatibility Ideographs", 0),
+            UnicodeBlock(61, 0x2F800, 0x2FA1F, "CJK Compatibility Ideographs Supplement", 3),
+        ],
+    ),
     UnicodeBlock(62, 0xFB00, 0xFB4F, "Alphabetic Presentation Forms", 0),
     UnicodeBlock(63, 0xFB50, 0xFDFF, "Arabic Presentation Forms-A", 0),
     UnicodeBlock(64, 0xFE20, 0xFE2F, "Combining Half Marks", 0),
-    UnicodeBlock(65, 0xFE10, 0xFE1F, "Vertical Forms", 4, [
-        UnicodeBlock(65, 0xFE30, 0xFE4F, "CJK Compatibility Forms", 0)
-    ]),
+    UnicodeBlock(
+        65,
+        0xFE10,
+        0xFE1F,
+        "Vertical Forms",
+        4,
+        [UnicodeBlock(65, 0xFE30, 0xFE4F, "CJK Compatibility Forms", 0)],
+    ),
     UnicodeBlock(66, 0xFE50, 0xFE6F, "Small Form Variants", 0),
     UnicodeBlock(67, 0xFE70, 0xFEFF, "Arabic Presentation Forms-B", 0),
     UnicodeBlock(68, 0xFF00, 0xFFEF, "Halfwidth And Fullwidth Forms", 0),
@@ -229,41 +313,72 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(72, 0x0780, 0x07BF, "Thaana", 2),
     UnicodeBlock(73, 0x0D80, 0x0DFF, "Sinhala", 2),
     UnicodeBlock(74, 0x1000, 0x109F, "Myanmar", 2),
-    UnicodeBlock(75, 0x1200, 0x137F, "Ethiopic", 2, [
-        UnicodeBlock(75, 0x1380, 0x139F, "Ethiopic Supplement", 4),
-        UnicodeBlock(75, 0x2D80, 0x2DDF, "Ethiopic Extended", 4)
-    ]),
+    UnicodeBlock(
+        75,
+        0x1200,
+        0x137F,
+        "Ethiopic",
+        2,
+        [
+            UnicodeBlock(75, 0x1380, 0x139F, "Ethiopic Supplement", 4),
+            UnicodeBlock(75, 0x2D80, 0x2DDF, "Ethiopic Extended", 4),
+        ],
+    ),
     UnicodeBlock(76, 0x13A0, 0x13FF, "Cherokee", 2),
     UnicodeBlock(77, 0x1400, 0x167F, "Unified Canadian Aboriginal Syllabics", 2),
     UnicodeBlock(78, 0x1680, 0x169F, "Ogham", 2),
     UnicodeBlock(79, 0x16A0, 0x16FF, "Runic", 2),
-    UnicodeBlock(80, 0x1780, 0x17FF, "Khmer", 2, [
-        UnicodeBlock(80, 0x19E0, 0x19FF, "Khmer Symbols", 4)
-    ]),
+    UnicodeBlock(
+        80, 0x1780, 0x17FF, "Khmer", 2, [UnicodeBlock(80, 0x19E0, 0x19FF, "Khmer Symbols", 4)]
+    ),
     UnicodeBlock(81, 0x1800, 0x18AF, "Mongolian", 2),
     UnicodeBlock(82, 0x2800, 0x28FF, "Braille Patterns", 2),
-    UnicodeBlock(83, 0xA000, 0xA48F, "Yi Syllables", 2, [
-        UnicodeBlock(83, 0xA490, 0xA4CF, "Yi Radicals", 2)
-    ]),
-    UnicodeBlock(84, 0x1700, 0x171F, "Tagalog", 3, [
-        UnicodeBlock(84, 0x1730, 0x173F, "Hanunoo", 3),
-        UnicodeBlock(84, 0x1740, 0x175F, "Buhid", 3),
-        UnicodeBlock(84, 0x1760, 0x177F, "Tagbanwa", 3)
-    ]),
+    UnicodeBlock(
+        83, 0xA000, 0xA48F, "Yi Syllables", 2, [UnicodeBlock(83, 0xA490, 0xA4CF, "Yi Radicals", 2)]
+    ),
+    UnicodeBlock(
+        84,
+        0x1700,
+        0x171F,
+        "Tagalog",
+        3,
+        [
+            UnicodeBlock(84, 0x1730, 0x173F, "Hanunoo", 3),
+            UnicodeBlock(84, 0x1740, 0x175F, "Buhid", 3),
+            UnicodeBlock(84, 0x1760, 0x177F, "Tagbanwa", 3),
+        ],
+    ),
     UnicodeBlock(85, 0x10300, 0x1032F, "Old Italic", 3),
     UnicodeBlock(86, 0x10330, 0x1034F, "Gothic", 3),
     UnicodeBlock(87, 0x10400, 0x1044F, "Deseret", 3),
-    UnicodeBlock(88, 0x1D000, 0x1D0FF, "Byzantine Musical Symbols", 3, [
-        UnicodeBlock(88, 0x1D100, 0x1D1FF, "Musical Symbols", 3),
-        UnicodeBlock(88, 0x1D200, 0x1D24F, "Ancient Greek Musical Notation", 4)
-    ]),
+    UnicodeBlock(
+        88,
+        0x1D000,
+        0x1D0FF,
+        "Byzantine Musical Symbols",
+        3,
+        [
+            UnicodeBlock(88, 0x1D100, 0x1D1FF, "Musical Symbols", 3),
+            UnicodeBlock(88, 0x1D200, 0x1D24F, "Ancient Greek Musical Notation", 4),
+        ],
+    ),
     UnicodeBlock(89, 0x1D400, 0x1D7FF, "Mathematical Alphanumeric Symbols", 3),
-    UnicodeBlock(90, 0xF000, 0xFFFF, "Private Use (plane 15)", 3, [
-        UnicodeBlock(90, 0x10000, 0x10FFFD, "Private Use (plane 16)", 3)
-    ]),
-    UnicodeBlock(91, 0xFE00, 0xFE0F, "Variation Selectors", 3, [
-        UnicodeBlock(91, 0xE0100, 0xE01EF, "Variation Selectors Supplement", 3)
-    ]),
+    UnicodeBlock(
+        90,
+        0xF000,
+        0xFFFF,
+        "Private Use (plane 15)",
+        3,
+        [UnicodeBlock(90, 0x10000, 0x10FFFD, "Private Use (plane 16)", 3)],
+    ),
+    UnicodeBlock(
+        91,
+        0xFE00,
+        0xFE0F,
+        "Variation Selectors",
+        3,
+        [UnicodeBlock(91, 0xE0100, 0xE01EF, "Variation Selectors Supplement", 3)],
+    ),
     UnicodeBlock(92, 0xE0000, 0xE007F, "Tags", 3),
     UnicodeBlock(93, 0x1900, 0x194F, "Limbu", 4),
     UnicodeBlock(94, 0x1950, 0x197F, "Tai Le", 4),
@@ -273,10 +388,17 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(98, 0x2D30, 0x2D7F, "Tifinagh", 4),
     UnicodeBlock(99, 0x4DC0, 0x4DFF, "Yijing Hexagram Symbols", 4),
     UnicodeBlock(100, 0xA800, 0xA82F, "Syloti Nagri", 4),
-    UnicodeBlock(101, 0x10000, 0x1007F, "Linear B Syllabary", 4, [
-        UnicodeBlock(101, 0x10080, 0x100FF, "Linear B Ideograms", 4),
-        UnicodeBlock(101, 0x10100, 0x1013F, "Aegean Numbers", 4)
-    ]),
+    UnicodeBlock(
+        101,
+        0x10000,
+        0x1007F,
+        "Linear B Syllabary",
+        4,
+        [
+            UnicodeBlock(101, 0x10080, 0x100FF, "Linear B Ideograms", 4),
+            UnicodeBlock(101, 0x10100, 0x1013F, "Aegean Numbers", 4),
+        ],
+    ),
     UnicodeBlock(102, 0x10140, 0x1018F, "Ancient Greek Numbers", 4),
     UnicodeBlock(103, 0x10380, 0x1039F, "Ugaritic", 4),
     UnicodeBlock(104, 0x103A0, 0x103DF, "Old Persian", 4),
@@ -285,9 +407,14 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(107, 0x10800, 0x1083F, "Cypriot Syllabary", 4),
     UnicodeBlock(108, 0x10A00, 0x10A5F, "Kharoshthi", 4),
     UnicodeBlock(109, 0x1D300, 0x1D35F, "Tai Xuan Jing Symbols", 4),
-    UnicodeBlock(110, 0x12000, 0x123FF, "Cuneiform", 4, [
-        UnicodeBlock(110, 0x12400, 0x1247F, "Cuneiform Numbers and Punctuation", 4)
-    ]),
+    UnicodeBlock(
+        110,
+        0x12000,
+        0x123FF,
+        "Cuneiform",
+        4,
+        [UnicodeBlock(110, 0x12400, 0x1247F, "Cuneiform Numbers and Punctuation", 4)],
+    ),
     UnicodeBlock(111, 0x1D360, 0x1D37F, "Counting Rod Numerals", 4),
     UnicodeBlock(112, 0x1B80, 0x1BBF, "Sundanese", 4),
     UnicodeBlock(113, 0x1C00, 0x1C4F, "Lepcha", 4),
@@ -298,13 +425,25 @@ OS_2_UNICODE_RANGES = [
     UnicodeBlock(118, 0xAA00, 0xAA5F, "Cham", 4),
     UnicodeBlock(119, 0x10190, 0x101CF, "Ancient Symbols", 4),
     UnicodeBlock(120, 0x101D0, 0x101FF, "Phaistos Disc", 4),
-    UnicodeBlock(121, 0x102A0, 0x102DF, "Carian", 4, [
-        UnicodeBlock(121, 0x10280, 0x1029F, "Lycian", 4),
-        UnicodeBlock(121, 0x10920, 0x1093F, "Lydian", 4)
-    ]),
-    UnicodeBlock(122, 0x1F030, 0x1F09F, "Domino Tiles", 4, [
-        UnicodeBlock(122, 0x1F000, 0x1F02F, "Mahjong Tiles", 4)
-    ]),
+    UnicodeBlock(
+        121,
+        0x102A0,
+        0x102DF,
+        "Carian",
+        4,
+        [
+            UnicodeBlock(121, 0x10280, 0x1029F, "Lycian", 4),
+            UnicodeBlock(121, 0x10920, 0x1093F, "Lydian", 4),
+        ],
+    ),
+    UnicodeBlock(
+        122,
+        0x1F030,
+        0x1F09F,
+        "Domino Tiles",
+        4,
+        [UnicodeBlock(122, 0x1F000, 0x1F02F, "Mahjong Tiles", 4)],
+    ),
 ]
 
 


### PR DESCRIPTION
This pull request includes several changes to the `foundrytools_cli_2` codebase, focusing on renaming functions, reformatting code, and improving the organization of Unicode block definitions. The most important changes include renaming the `recalc_ranges` function, reformatting the `UnicodeBlock` class, and cleaning up whitespace.

Function renaming and reformatting:

* [`foundrytools_cli_2/cli/os_2/cli.py`](diffhunk://#diff-96185ae4596718cc81b290ad673c76eb7804877776fc9dc47dd8805b11b698f1L69-R87): Renamed the `recalc_ranges` function to `recalc_codepage_ranges` and updated its command name and docstring accordingly.

Code cleanup and reformatting:

* [`foundrytools_cli_2/lib/utils/unicode_tools.py`](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L152-R234): Reformatted the `UnicodeBlock` class definitions to improve readability and consistency. [[1]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L152-R234) [[2]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L191-R306) [[3]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L232-R381) [[4]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L276-R401) [[5]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L301-R446)
* [`foundrytools_cli_2/lib/font/tables/os_2.py`](diffhunk://#diff-0bb4a80484213b70034bbb5a257d05b73230d30c4f027e7e8db71300a45affc7L623): Removed unnecessary whitespace in the `recalc_code_page_ranges` function.
* [`foundrytools_cli_2/lib/utils/unicode_tools.py`](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L19): Removed unnecessary whitespace in various functions. [[1]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L19) [[2]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2R34) [[3]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2R83) [[4]](diffhunk://#diff-847426f368a4a3f1a36c3c9b93399a0a385339ea639fcc8eb715c428f76032f2L111-R163)