### PR TITLE
Improve path sanitization

### DIFF
--- a/foundrytools_cli_2/cli/utils/snippets/font_organizer.py
+++ b/foundrytools_cli_2/cli/utils/snippets/font_organizer.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pathvalidate import sanitize_filepath
+from pathvalidate import sanitize_filename, sanitize_filepath
 
 from foundrytools_cli_2.cli.logger import logger
 from foundrytools_cli_2.lib.font import Font
@@ -28,19 +28,17 @@ def _determine_output_directory(
     Returns:
         Path: The sanitized output directory path.
     """
-    family_name = font.get_best_family_name().strip()
-    manufacturer_name = font.get_manufacturer()
-    font_revision = "v" + font.get_font_revision()
+    family_name = sanitize_filename(font.get_best_family_name())
+    manufacturer_name = sanitize_filename(font.get_manufacturer())
+    font_revision = "v" + sanitize_filename(font.get_font_revision())
     extension = font.get_real_extension().replace(".", "")
 
     out_dir = base_dir
 
     if sort_by_manufacturer and manufacturer_name:
-        manufacturer_name = manufacturer_name.strip()
         out_dir = out_dir.joinpath(manufacturer_name)
 
     if sort_by_font_revision and font_revision:
-        font_revision = font_revision.strip()
         out_dir = out_dir.joinpath(f"{family_name} {font_revision}")
     else:
         out_dir = out_dir.joinpath(family_name)


### PR DESCRIPTION
This pull request includes changes to enhance the sanitization of file and directory names in the `font_organizer.py` utility. The most important changes involve using the `sanitize_filename` function to ensure all components of the output directory path are properly sanitized.

Sanitization improvements:

* [`foundrytools_cli_2/cli/utils/snippets/font_organizer.py`](diffhunk://#diff-19b261acaaddf1833b278c06fb46a5d2f087d469367289ae2214a9a97841e557L3-R3): Imported `sanitize_filename` from `pathvalidate` to sanitize filenames in addition to file paths.
* [`foundrytools_cli_2/cli/utils/snippets/font_organizer.py`](diffhunk://#diff-19b261acaaddf1833b278c06fb46a5d2f087d469367289ae2214a9a97841e557L31-L43): Updated the `_determine_output_directory` function to use `sanitize_filename` for `family_name`, `manufacturer_name`, and `font_revision` to ensure all parts of the output directory are sanitized.