### PR TITLE
Refactoring

### DIFF
--- a/foundrytools_cli_2/cli/fix/cli.py
+++ b/foundrytools_cli_2/cli/fix/cli.py
@@ -70,7 +70,7 @@ def fix_duplicate_components(input_path: Path, **options: t.Dict[str, t.Any]) ->
     runner.run()
 
 
-@cli.command("notdef-empty")
+@cli.command("empty-notdef")
 @base_options()
 def fix_empty_notdef(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     """
@@ -81,7 +81,7 @@ def fix_empty_notdef(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     an outline as the user will only see what looks like a space if a glyph is missing and not be
     aware of the active font’s limitation.
     """
-    from foundrytools_cli_2.cli.fix.tasks.empty_notdef import fix_notdef_empty as task
+    from foundrytools_cli_2.cli.fix.tasks.empty_notdef import fix_empty_notdef as task
 
     runner = TaskRunner(input_path=input_path, task=task, **options)
     runner.run()

--- a/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
+++ b/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
@@ -87,7 +87,7 @@ def draw_empty_notdef_glyf(font: Font, width: int, height: int, thickness: int) 
     return pen.glyph()
 
 
-def fix_notdef_empty(font: Font) -> None:
+def fix_empty_notdef(font: Font) -> None:
     """
     Fixes the empty .notdef glyph by adding a simple rectangle.
 

--- a/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
+++ b/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
@@ -1,5 +1,6 @@
 from fontTools.misc.psCharStrings import T2CharString
 from fontTools.misc.roundTools import otRound
+from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables._g_l_y_f import Glyph
@@ -9,7 +10,6 @@ from foundrytools_cli_2.lib.constants import (
 )
 from foundrytools_cli_2.lib.font import Font
 from foundrytools_cli_2.lib.font.tables import CFFTable, GlyfTable, HeadTable, OS2Table
-from foundrytools_cli_2.lib.skia.skia_tools import is_empty_glyph
 
 NOTDEF = ".notdef"
 WIDTH_CONSTANT = 600
@@ -30,7 +30,6 @@ def draw_empty_notdef_cff(font: Font, width: int, height: int, thickness: int) -
     Returns:
         T2CharString: The .notdef glyph charstring.
     """
-
     pen = T2CharStringPen(width=0, glyphSet=font.glyph_set)
 
     # Draw the outer contour (counterclockwise)
@@ -98,10 +97,12 @@ def fix_notdef_empty(font: Font) -> None:
     glyph_set = font.glyph_set
 
     if NOTDEF not in glyph_set:
-        raise ValueError("Font does not contain a .notdef glyph")
+        raise KeyError("Font does not contain a .notdef glyph")
 
-    if not is_empty_glyph(glyph_set=glyph_set, glyph_name=NOTDEF):
-        return
+    rec_pen = RecordingPen()
+    glyph_set[NOTDEF].draw(rec_pen)
+    if rec_pen.value:
+        raise ValueError("The .notdef glyph is not empty")
 
     os_2_table = OS2Table(ttfont=font.ttfont)
     head_table = HeadTable(ttfont=font.ttfont)

--- a/foundrytools_cli_2/lib/skia/skia_tools.py
+++ b/foundrytools_cli_2/lib/skia/skia_tools.py
@@ -9,7 +9,7 @@ from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables import _g_l_y_f, _h_m_t_x
-from fontTools.ttLib.ttGlyphSet import _TTGlyph, _TTGlyphSet
+from fontTools.ttLib.ttGlyphSet import _TTGlyph
 
 from foundrytools_cli_2.lib.constants import T_CFF, T_GLYF, T_HMTX
 
@@ -452,19 +452,3 @@ def correct_glyphs_contours(
         )
 
     return modified_glyphs
-
-
-def is_empty_glyph(glyph_set: _TTGlyphSet, glyph_name: str) -> bool:
-    """
-    Returns True if the glyph is empty.
-
-    Args:
-        glyph_set (_TTGlyphSet): The glyph set.
-        glyph_name (str): The name of the glyph.
-
-    Returns:
-        bool: ``True`` if the glyph is empty, ``False`` otherwise.
-    """
-
-    path = skia_path_from_glyph(glyph_name=glyph_name, glyph_set=glyph_set)
-    return path.area == 0


### PR DESCRIPTION
This pull request includes several changes to the `foundrytools_cli_2` package, primarily focusing on renaming functions and imports for clarity, and removing an unused method. The most important changes include renaming the `fix_notdef_empty` function to `fix_empty_notdef`, updating the corresponding import statements, and removing the `is_empty_glyph` method.

Function and import renaming:

* [`foundrytools_cli_2/cli/fix/cli.py`](diffhunk://#diff-ee567159f5ee502ec31827dc4d42ffbdc52b5e5e0b6343b7a0fb3ad1b211df68L73-R73): Renamed the `fix_notdef_empty` function to `fix_empty_notdef` and updated the corresponding import statement. (`[[1]](diffhunk://#diff-ee567159f5ee502ec31827dc4d42ffbdc52b5e5e0b6343b7a0fb3ad1b211df68L73-R73)`, `[[2]](diffhunk://#diff-ee567159f5ee502ec31827dc4d42ffbdc52b5e5e0b6343b7a0fb3ad1b211df68L84-R84)`)
* [`foundrytools_cli_2/cli/fix/tasks/empty_notdef.py`](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL91-R90): Renamed the `fix_notdef_empty` function to `fix_empty_notdef` and updated the error handling to raise a `KeyError` if the `.notdef` glyph is missing. (`[[1]](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL91-R90)`, `[[2]](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL101-R105)`)

Code cleanup:

* [`foundrytools_cli_2/cli/fix/tasks/empty_notdef.py`](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL12): Removed the import of the unused `is_empty_glyph` method. (`[foundrytools_cli_2/cli/fix/tasks/empty_notdef.pyL12](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL12)`)
* [`foundrytools_cli_2/lib/skia/skia_tools.py`](diffhunk://#diff-18bc875cc616cb99db61bba5cd89505d30a4aac516d2f0bcc15744b3ea6b4ac6L455-L470): Removed the `is_empty_glyph` method as it is no longer used. (`[foundrytools_cli_2/lib/skia/skia_tools.pyL455-L470](diffhunk://#diff-18bc875cc616cb99db61bba5cd89505d30a4aac516d2f0bcc15744b3ea6b4ac6L455-L470)`)

Additional import:

* [`foundrytools_cli_2/cli/fix/tasks/empty_notdef.py`](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aR3): Added the `RecordingPen` import to assist in checking if the `.notdef` glyph is empty. (`[foundrytools_cli_2/cli/fix/tasks/empty_notdef.pyR3](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aR3)`)