### PR TITLE
Refactoring

### DIFF
--- a/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
+++ b/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
@@ -1,7 +1,4 @@
-from fontTools.subset import Options, Subsetter
-
 from foundrytools_cli_2.cli.logger import logger
-from foundrytools_cli_2.lib.constants import T_CMAP
 from foundrytools_cli_2.lib.font import Font
 
 
@@ -15,46 +12,8 @@ def main(font: Font, recalc_timestamp: bool = False) -> None:
     Returns:
         None
     """
-    options = Options()
-    options.drop_tables = []
-    options.passthrough_tables = True
-    options.hinting_tables = ["*"]
-    options.layout_features = ["*"]
-    options.legacy_kern = True
-    options.layout_closure = True
-    options.layout_scripts = ["*"]
-    options.ignore_missing_unicodes = True
-    options.hinting = True
-    options.glyph_names = True
-    options.legacy_cmap = True
-    options.symbol_cmap = True
-    options.name_IDs = ["*"]
-    options.name_legacy = True
-    options.name_languages = ["*"]
-    options.retain_gids = False
-    options.notdef_glyph = True
-    options.notdef_outline = True
-    options.recalc_bounds = True
-    options.recalc_timestamp = recalc_timestamp
-    options.prune_unicode_ranges = True
-    options.prune_codepage_ranges = True
-    options.recalc_average_width = True
-    options.recalc_max_context = True
-    options.canonical_order = False
+    removed_glyphs = font.remove_unreachable_glyphs(recalc_timestamp=recalc_timestamp)
 
-    old_glyph_order = font.ttfont.getGlyphOrder()
-    unicodes = []
-    for t in font.ttfont[T_CMAP].tables:
-        if t.isUnicode():
-            unicodes.extend(t.cmap.keys())
-    subsetter = Subsetter(options=options)
-    subsetter.populate(unicodes=unicodes)
-    subsetter.subset(font=font.ttfont)
-    new_glyph_order = font.ttfont.getGlyphOrder()
-
-    font.modified = new_glyph_order != old_glyph_order
-    removed_glyphs = set(old_glyph_order) - set(new_glyph_order)
     if removed_glyphs:
-        logger.opt(colors=True).info(
-            f"{len(removed_glyphs)} glyphs has been removed: \n" f"{', '.join(removed_glyphs)}"
-        )
+        logger.info(f"Removed {len(removed_glyphs)} unreachable glyphs")
+        font.modified = True

--- a/foundrytools_cli_2/lib/constants.py
+++ b/foundrytools_cli_2/lib/constants.py
@@ -76,6 +76,35 @@ class NameIds(IntEnum):
     VARIATIONS_POSTSCRIPT_NAME_PREFIX = 25
 
 
+SUBSETTER_DEFAULTS = {
+    "drop_tables": [],
+    "passthrough_tables": True,
+    "hinting_tables": ["*"],
+    "layout_features": ["*"],
+    "legacy_kern": True,
+    "layout_closure": True,
+    "layout_scripts": ["*"],
+    "ignore_missing_unicodes": True,
+    "hinting": True,
+    "glyph_names": True,
+    "legacy_cmap": True,
+    "symbol_cmap": True,
+    "name_IDs": ["*"],
+    "name_legacy": True,
+    "name_languages": ["*"],
+    "retain_gids": False,
+    "notdef_glyph": True,
+    "notdef_outline": True,
+    "recalc_bounds": True,
+    "recalc_timestamp": False,
+    "prune_unicode_ranges": True,
+    "prune_codepage_ranges": True,
+    "recalc_average_width": True,
+    "recalc_max_context": True,
+    "canonical_order": False,
+}
+
+
 NAME_IDS_TO_DESCRIPTION = {
     0: "Copyright Notice",
     1: "Family name",

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -1003,16 +1003,7 @@ class Font:  # pylint: disable=too-many-public-methods
 
     def set_production_names(self) -> t.List[t.Tuple[str, str]]:
         """
-
-        Set the production names for the glyphs in the TrueType font.
-
-        Returns a list of tuples containing the original glyph name and its corresponding
-        production name.
-
-        - `old_glyph_order`: A list of strings representing the original glyph order in the
-        underlying TTFont object.
-        - `reversed_cmap`: An instance of `_ReversedCmap` representing  the reversed cmap table of
-        the TrueType font.
+        Set the production names for the glyphs in the font.
 
         Returns:
             A list of tuples, where each tuple contains the original glyph name and its production
@@ -1021,9 +1012,9 @@ class Font:  # pylint: disable=too-many-public-methods
         The method iterates through each glyph in the old glyph order and determines its production
         name based on its assigned or calculated Unicode value. If the production name is already
         assigned, the glyph is skipped. If the production name is different from the original glyph
-        name and is not already assigned, the glyph is renamed and added to the new glyph order
-        list. Finally, the font is updated with the new glyph order, the cmap table is rebuilt, and
-        the list of renamed glyphs is returned.
+        name and is not yet assigned, the glyph is renamed and added to the new glyph order list.
+        Finally, the font is updated with the new glyph order, the cmap table is rebuilt, and the
+        list of renamed glyphs is returned.
         """
         old_glyph_order: t.List[str] = self.ttfont.getGlyphOrder()
         reversed_cmap: _ReversedCmap = self.ttfont[T_CMAP].buildReversed()

--- a/foundrytools_cli_2/lib/font/tables/cmap.py
+++ b/foundrytools_cli_2/lib/font/tables/cmap.py
@@ -20,7 +20,7 @@ class CmapTable(DefaultTbl):  # pylint: disable=too-few-public-methods
         Fixes the missing non-breaking space glyph by double mapping the space glyph.
         """
         # Get the space glyph
-        best_cmap = self.ttfont.getBestCmap()
+        best_cmap = self.table.getBestCmap()
         space_glyph = best_cmap.get(0x0020)
         if space_glyph is None:
             return
@@ -31,6 +31,6 @@ class CmapTable(DefaultTbl):  # pylint: disable=too-few-public-methods
             return
 
         # Copy the space glyph to the non-breaking space glyph
-        for table in self.ttfont["cmap"].tables:
+        for table in self.table.tables:
             if table.isUnicode():
                 table.cmap[0x00A0] = space_glyph


### PR DESCRIPTION
This pull request includes several changes to the `foundrytools_cli_2` project, primarily focusing on refactoring the handling of unreachable glyphs and improving code clarity. The most important changes include removing direct usage of the `Subsetter` and `Options` classes from `fontTools`, centralizing subsetter options, and adding a new method to the `Font` class.

Refactoring and code simplification:

* [`foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py`](diffhunk://#diff-0f0b7442d9ad8bb1d23fa3ef32ce3e1cd3131cfeeb12ed2ad06711b3a5f32760L18-R19): Removed direct usage of `Subsetter` and `Options` classes, replacing them with a call to the new `remove_unreachable_glyphs` method in the `Font` class.
* [`foundrytools_cli_2/lib/constants.py`](diffhunk://#diff-03cd8ec3261f8e8243e2ff922cb9073445d6c7764bdbf3ec5c695897df149b6bR79-R107): Centralized subsetter options into a new dictionary `SUBSETTER_DEFAULTS`.
* [`foundrytools_cli_2/lib/font/font.py`](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465R1115-R1138): Added `remove_unreachable_glyphs` method to the `Font` class, encapsulating the logic for removing unreachable glyphs using the subsetter options.

Code cleanup and minor improvements:

* [`foundrytools_cli_2/lib/font/font.py`](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465L1006-R1008): Cleaned up and clarified docstrings in the `set_production_names` method. [[1]](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465L1006-R1008) [[2]](diffhunk://#diff-beca67e35e46ebebb2d27441035641f2753508243f1aab52016bf15444198465L1024-R1019)
* [`foundrytools_cli_2/lib/font/tables/cmap.py`](diffhunk://#diff-a94509b7a27a2ad71fdad96de8f33237fba399c32785b8408378c2f9b200eb8bL23-R23): Fixed references to `self.ttfont` by replacing them with `self.table` to improve code readability and correctness. [[1]](diffhunk://#diff-a94509b7a27a2ad71fdad96de8f33237fba399c32785b8408378c2f9b200eb8bL23-R23) [[2]](diffhunk://#diff-a94509b7a27a2ad71fdad96de8f33237fba399c32785b8408378c2f9b200eb8bL34-R34)