### PR TITLE
Refactoring

### DIFF
--- a/foundrytools_cli_2/cli/cff/tasks.py
+++ b/foundrytools_cli_2/cli/cff/tasks.py
@@ -15,7 +15,7 @@ def set_names(font: Font, **kwargs: t.Dict[str, str]) -> None:
 
     cff_table = CFFTable(font.ttfont)
     cff_table.set_names(**kwargs)
-    font.modified = cff_table.modified
+    font.is_modified = cff_table.is_modified
 
 
 def del_names(font: Font, **kwargs: t.Dict[str, str]) -> None:
@@ -29,7 +29,7 @@ def del_names(font: Font, **kwargs: t.Dict[str, str]) -> None:
 
     cff_table = CFFTable(font.ttfont)
     cff_table.del_names(**kwargs)
-    font.modified = cff_table.modified
+    font.is_modified = cff_table.is_modified
 
 
 def find_replace(font: Font, old_string: str, new_string: str) -> None:
@@ -44,4 +44,4 @@ def find_replace(font: Font, old_string: str, new_string: str) -> None:
 
     cff_table = CFFTable(font.ttfont)
     cff_table.find_replace(old_string, new_string)
-    font.modified = cff_table.modified
+    font.is_modified = cff_table.is_modified

--- a/foundrytools_cli_2/cli/experimental/tasks/recalc_stems.py
+++ b/foundrytools_cli_2/cli/experimental/tasks/recalc_stems.py
@@ -168,4 +168,4 @@ def main(font: Font) -> None:
     else:
         set_font_stems(font.ttfont, std_h_w, std_v_w)
         font.ttfont.flavor = flavor
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/experimental/tasks/recalc_zones.py
+++ b/foundrytools_cli_2/cli/experimental/tasks/recalc_zones.py
@@ -316,4 +316,4 @@ def main(font: Font) -> None:
         logger.info("Zones are already up-to-date")
     else:
         set_font_zones(font.ttfont, other_blues, blue_values)
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/contours.py
+++ b/foundrytools_cli_2/cli/fix/tasks/contours.py
@@ -34,5 +34,5 @@ def main(
         logger.info("No glyphs were modified")
         return
 
-    font.modified = True
+    font.is_modified = True
     logger.info(f"{len(modified_glyphs)} glyphs were modified: {', '.join(modified_glyphs)}")

--- a/foundrytools_cli_2/cli/fix/tasks/decompose_transformed.py
+++ b/foundrytools_cli_2/cli/fix/tasks/decompose_transformed.py
@@ -11,4 +11,4 @@ def main(font: Font) -> None:
         logger.info(
             f"Decomposed transformed components in the following glyphs: {', '.join(transformed)}"
         )
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/duplicate_components.py
+++ b/foundrytools_cli_2/cli/fix/tasks/duplicate_components.py
@@ -11,4 +11,4 @@ def main(font: Font) -> None:
         logger.info(
             f"Removed duplicate components in the following glyphs: {', '.join(fixed_glyphs)}"
         )
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
+++ b/foundrytools_cli_2/cli/fix/tasks/empty_notdef.py
@@ -125,4 +125,4 @@ def fix_empty_notdef(font: Font) -> None:
         glyf_table.table[NOTDEF] = glyph
 
     font.ttfont[T_HMTX][NOTDEF] = (width, 0)
-    font.modified = True
+    font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/fs_selection.py
+++ b/foundrytools_cli_2/cli/fix/tasks/fs_selection.py
@@ -13,9 +13,9 @@ def main(font: Font) -> None:
     # If the font is not bold or italic, set it to regular
     if not (font.is_bold or font.is_italic or font.is_regular):
         font.is_regular = True
-        font.modified = True
+        font.is_modified = True
 
     # If the font is bold or italic, set it to not regular
     elif (font.is_bold or font.is_italic) and font.is_regular:
         font.is_regular = False
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/italic_angle.py
+++ b/foundrytools_cli_2/cli/fix/tasks/italic_angle.py
@@ -47,7 +47,7 @@ def check_post_table(font: Font, calculated_italic_angle: int) -> None:
     if check_passed:
         return
     post_table.italic_angle = calculated_italic_angle
-    font.modified = True
+    font.is_modified = True
 
 
 def check_hhea_table(font: Font, calculated_italic_angle: int) -> None:
@@ -73,7 +73,7 @@ def check_hhea_table(font: Font, calculated_italic_angle: int) -> None:
         return
     hhea_table.caret_slope_rise = calculated_rise
     hhea_table.caret_slope_run = calculated_run
-    font.modified = True
+    font.is_modified = True
 
 
 def check_cff_table(font: Font, calculated_italic_angle: int) -> None:
@@ -96,7 +96,7 @@ def check_cff_table(font: Font, calculated_italic_angle: int) -> None:
     if check_passed:
         return
     cff_table.top_dict.ItalicAngle = calculated_italic_angle
-    font.modified = True
+    font.is_modified = True
 
 
 def check_italic_bits(font: Font, calculated_italic_angle: int, mode: int) -> None:
@@ -122,7 +122,7 @@ def check_italic_bits(font: Font, calculated_italic_angle: int, mode: int) -> No
     if check_passed:
         return
     font.is_italic = should_be_italic
-    font.modified = True
+    font.is_modified = True
 
 
 def check_oblique_bit(font: Font, calculated_italic_angle: int, mode: int) -> None:
@@ -148,7 +148,7 @@ def check_oblique_bit(font: Font, calculated_italic_angle: int, mode: int) -> No
     if check_passed:
         return
     font.is_oblique = should_be_oblique
-    font.modified = True
+    font.is_modified = True
 
 
 def main(font: Font, min_slant: float = 2.0, mode: int = 1) -> None:

--- a/foundrytools_cli_2/cli/fix/tasks/kern_table.py
+++ b/foundrytools_cli_2/cli/fix/tasks/kern_table.py
@@ -11,4 +11,4 @@ def main(font: Font) -> None:
         return
     kern_table = KernTable(ttfont=font.ttfont)
     kern_table.remove_unmapped_glyphs()
-    font.modified = kern_table.modified
+    font.is_modified = kern_table.is_modified

--- a/foundrytools_cli_2/cli/fix/tasks/legacy_accents.py
+++ b/foundrytools_cli_2/cli/fix/tasks/legacy_accents.py
@@ -54,4 +54,4 @@ def fix_legacy_accents(font: Font) -> None:
             logger.info(
                 f"Deleted {len(deleted)} legacy accents from GDEF table: {', '.join(deleted)}"
             )
-        font.modified = gdef.modified
+        font.is_modified = gdef.is_modified

--- a/foundrytools_cli_2/cli/fix/tasks/monospace.py
+++ b/foundrytools_cli_2/cli/fix/tasks/monospace.py
@@ -23,11 +23,11 @@ def main(font: Font) -> None:
         os2_table.table.panose.bProportion = 9
         hhea_table.advance_width_max = width_max
 
-        modified = os2_table.modified or post_table.modified or hhea_table.modified
+        modified = os2_table.is_modified or post_table.is_modified or hhea_table.is_modified
 
         if font.is_ps:
             cff_table = CFFTable(ttfont=font.ttfont)
             cff_table.top_dict.isFixedPitch = True
-            modified = cff_table.modified or modified
+            modified = cff_table.is_modified or modified
 
-        font.modified = modified
+        font.is_modified = modified

--- a/foundrytools_cli_2/cli/fix/tasks/nbsp_missing.py
+++ b/foundrytools_cli_2/cli/fix/tasks/nbsp_missing.py
@@ -8,4 +8,4 @@ def main(font: Font) -> None:
     """
     cmap_table = CmapTable(ttfont=font.ttfont)
     cmap_table.add_missing_non_breaking_space()
-    font.modified = cmap_table.modified
+    font.is_modified = cmap_table.is_modified

--- a/foundrytools_cli_2/cli/fix/tasks/nbsp_width.py
+++ b/foundrytools_cli_2/cli/fix/tasks/nbsp_width.py
@@ -8,4 +8,4 @@ def main(font: Font) -> None:
     """
     hmtx_table = HmtxTable(ttfont=font.ttfont)
     hmtx_table.fix_non_breaking_space_width()
-    font.modified = hmtx_table.modified
+    font.is_modified = hmtx_table.is_modified

--- a/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
+++ b/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
@@ -16,4 +16,4 @@ def main(font: Font, recalc_timestamp: bool = False) -> None:
 
     if removed_glyphs:
         logger.info(f"Removed {len(removed_glyphs)} unreachable glyphs")
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
+++ b/foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py
@@ -12,7 +12,7 @@ def main(font: Font, recalc_timestamp: bool = False) -> None:
     Returns:
         None
     """
-    removed_glyphs = font.remove_unreachable_glyphs(recalc_timestamp=recalc_timestamp)
+    removed_glyphs = font.remove_unused_glyphs(recalc_timestamp=recalc_timestamp)
 
     if removed_glyphs:
         logger.info(f"Removed {len(removed_glyphs)} unreachable glyphs")

--- a/foundrytools_cli_2/cli/fix/tasks/vertical_metrics.py
+++ b/foundrytools_cli_2/cli/fix/tasks/vertical_metrics.py
@@ -28,4 +28,4 @@ def main(font: Font, safe_bottom: int, safe_top: int) -> None:
     if os_table.version >= 4:
         os_table.fs_selection.use_typo_metrics = True
 
-    font.modified = os_table.modified or hhea_table.modified
+    font.is_modified = os_table.is_modified or hhea_table.is_modified

--- a/foundrytools_cli_2/cli/glyphs/tasks/rebuild_cmap.py
+++ b/foundrytools_cli_2/cli/glyphs/tasks/rebuild_cmap.py
@@ -39,4 +39,4 @@ def main(font: Font, remap_all: bool = False) -> None:
     cmap_table = font.ttfont["cmap"]
     result = font.rebuild_cmap(remap_all=remap_all)
     print_results(**result)
-    font.modified = font.ttfont["cmap"].compile(font.ttfont) != cmap_table.compile(font.ttfont)
+    font.is_modified = font.ttfont["cmap"].compile(font.ttfont) != cmap_table.compile(font.ttfont)

--- a/foundrytools_cli_2/cli/glyphs/tasks/rename_glyph.py
+++ b/foundrytools_cli_2/cli/glyphs/tasks/rename_glyph.py
@@ -12,4 +12,4 @@ def main(font: Font, old_name: str, new_name: str) -> None:
     """
     result = font.rename_glyph(old_name=old_name, new_name=new_name)
     if result:
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/glyphs/tasks/rename_glyphs.py
+++ b/foundrytools_cli_2/cli/glyphs/tasks/rename_glyphs.py
@@ -25,4 +25,4 @@ def main(font: Font, source_file: Path) -> None:
     result = font.rename_glyphs(new_glyph_order=new_glyph_order)
     if result:
         font.rebuild_cmap(remap_all=True)
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/glyphs/tasks/set_production_names.py
+++ b/foundrytools_cli_2/cli/glyphs/tasks/set_production_names.py
@@ -25,4 +25,4 @@ def main(font: Font) -> None:
     renamed_glyphs = font.set_production_names()
     if renamed_glyphs:
         _print_results(renamed_glyphs)
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/glyphs/tasks/sort_glyphs.py
+++ b/foundrytools_cli_2/cli/glyphs/tasks/sort_glyphs.py
@@ -41,4 +41,4 @@ def main(
     if new_glyph_order == original_glyph_order:
         return
     font.sort_glyphs(new_glyph_order=new_glyph_order)
-    font.modified = True
+    font.is_modified = True

--- a/foundrytools_cli_2/cli/gsub/tasks/rename_feature.py
+++ b/foundrytools_cli_2/cli/gsub/tasks/rename_feature.py
@@ -21,7 +21,7 @@ def main(font: Font, old_feature_name: str, new_feature_name: str) -> None:
         for feature_record in gsub.table.table.FeatureList.FeatureRecord:
             if feature_record.FeatureTag == old_feature_name:
                 feature_record.FeatureTag = new_feature_name
-                font.modified = True
+                font.is_modified = True
         return
 
     logger.info(f"GSUB feature '{old_feature_name}' not found")

--- a/foundrytools_cli_2/cli/name/tasks.py
+++ b/foundrytools_cli_2/cli/name/tasks.py
@@ -26,7 +26,7 @@ def del_names(
     name_table.remove_names(
         name_ids=name_ids_to_process, platform_id=platform_id, language_string=language_string
     )
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def del_empty_names(font: Font) -> None:
@@ -39,7 +39,7 @@ def del_empty_names(font: Font) -> None:
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.remove_empty_names()
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def del_mac_names(
@@ -61,7 +61,7 @@ def del_mac_names(
     if not delete_all:
         name_ids_to_delete.difference_update({1, 2, 4, 5, 6})
     name_table.remove_names(name_ids=name_ids_to_delete, platform_id=1)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def del_unused_names(font: Font) -> None:
@@ -74,7 +74,7 @@ def del_unused_names(font: Font) -> None:
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.table.removeUnusedNames(font.ttfont)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def find_replace(
@@ -104,7 +104,7 @@ def find_replace(
         name_ids_to_process=name_ids_to_process,
         name_ids_to_skip=name_ids_to_skip,
     )
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def set_name(
@@ -132,7 +132,7 @@ def set_name(
         platform_id=platform_id,
         language_string=language_string,
     )
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def strip_names(font: Font) -> None:
@@ -144,7 +144,7 @@ def strip_names(font: Font) -> None:
     """
     name_table = NameTable(ttfont=font.ttfont)
     name_table.strip_names()
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def build_unique_id(
@@ -161,7 +161,7 @@ def build_unique_id(
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.build_unique_identifier(platform_id=platform_id, alternate=alternate)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def build_full_font_name(font: Font, platform_id: t.Optional[int] = None) -> None:
@@ -175,7 +175,7 @@ def build_full_font_name(font: Font, platform_id: t.Optional[int] = None) -> Non
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.build_full_font_name(platform_id=platform_id)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def build_version_string(font: Font, platform_id: t.Optional[int] = None) -> None:
@@ -189,7 +189,7 @@ def build_version_string(font: Font, platform_id: t.Optional[int] = None) -> Non
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.build_version_string(platform_id=platform_id)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def build_postscript_name(font: Font, platform_id: t.Optional[int] = None) -> None:
@@ -204,7 +204,7 @@ def build_postscript_name(font: Font, platform_id: t.Optional[int] = None) -> No
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.build_postscript_name(platform_id=platform_id)
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified
 
 
 def build_mac_names(font: Font) -> None:
@@ -217,4 +217,4 @@ def build_mac_names(font: Font) -> None:
 
     name_table = NameTable(ttfont=font.ttfont)
     name_table.build_mac_names()
-    font.modified = name_table.modified
+    font.is_modified = name_table.is_modified

--- a/foundrytools_cli_2/cli/os_2/tasks.py
+++ b/foundrytools_cli_2/cli/os_2/tasks.py
@@ -15,7 +15,7 @@ def recalc_avg_char_width(font: Font) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.recalc_avg_char_width()
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def recalc_cap_height(font: Font) -> None:
@@ -28,7 +28,7 @@ def recalc_cap_height(font: Font) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.recalc_cap_height()
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def recalc_x_height(font: Font) -> None:
@@ -41,7 +41,7 @@ def recalc_x_height(font: Font) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.recalc_x_height()
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def recalc_max_context(font: Font) -> None:
@@ -54,7 +54,7 @@ def recalc_max_context(font: Font) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.recalc_max_context()
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def recalc_unicode_ranges(font: Font, percentage: float = 33) -> None:
@@ -72,7 +72,7 @@ def recalc_unicode_ranges(font: Font, percentage: float = 33) -> None:
     if result:
         for block in result:
             logger.info(f"({block[0]}) {block[1]}: {block[2]}")
-        font.modified = True
+        font.is_modified = True
 
 
 def recalc_codepage_ranges(font: Font) -> None:
@@ -85,7 +85,7 @@ def recalc_codepage_ranges(font: Font) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.recalc_code_page_ranges()
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def set_attrs(
@@ -138,7 +138,7 @@ def set_attrs(
                 setattr(os_2_table, attr, value)
             except (ValueError, os_2_table.InvalidOS2VersionError) as e:
                 logger.error(f"Error setting {attr} to {value}: {e}")
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def set_fs_selection(
@@ -183,7 +183,7 @@ def set_fs_selection(
         os_2_table.fs_selection.oblique = oblique
     # IMPORTANT: head_table.modified must be evaluated before os_2_table.modified to suppress
     # fontTools warning about non-matching bits.
-    font.modified = head_table.modified or os_2_table.modified
+    font.is_modified = head_table.is_modified or os_2_table.is_modified
 
 
 def set_fs_type(
@@ -211,7 +211,7 @@ def set_fs_type(
     for attr, value in attrs.items():
         if value is not None:
             setattr(os_2_table, attr, value)
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def upgrade_version(font: Font, target_version: int) -> None:
@@ -225,7 +225,7 @@ def upgrade_version(font: Font, target_version: int) -> None:
 
     os_2_table = OS2Table(font.ttfont)
     os_2_table.upgrade(target_version)
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified
 
 
 def set_panose(font: Font, **kwargs: t.Dict[str, int]) -> None:
@@ -240,4 +240,4 @@ def set_panose(font: Font, **kwargs: t.Dict[str, int]) -> None:
     for key, value in kwargs.items():
         if value is not None:
             setattr(os_2_table.table.panose, key, value)
-    font.modified = os_2_table.modified
+    font.is_modified = os_2_table.is_modified

--- a/foundrytools_cli_2/cli/otf/tasks.py
+++ b/foundrytools_cli_2/cli/otf/tasks.py
@@ -18,7 +18,7 @@ def add_extremes(font: Font, drop_hinting_data: bool = False, subroutinize: bool
     if subroutinize:
         logger.info("Subroutinizing")
         font.ps_subroutinize()
-    font.modified = True
+    font.is_modified = True
 
 
 def autohint(font: Font, subroutinize: bool = True, **kwargs: t.Dict[str, t.Any]) -> None:
@@ -35,7 +35,7 @@ def autohint(font: Font, subroutinize: bool = True, **kwargs: t.Dict[str, t.Any]
         font.reload()  # DO NOT REMOVE
         logger.info("Subroutinizing")
         font.ps_subroutinize()
-    font.modified = True
+    font.is_modified = True
 
 
 def dehint(font: Font, drop_hinting_data: bool = False, subroutinize: bool = True) -> None:
@@ -52,7 +52,7 @@ def dehint(font: Font, drop_hinting_data: bool = False, subroutinize: bool = Tru
     if subroutinize:
         logger.info("Subroutinizing")
         font.ps_subroutinize()
-    font.modified = True
+    font.is_modified = True
 
 
 def check_outlines(font: Font, subroutinize: bool = True) -> None:
@@ -68,7 +68,7 @@ def check_outlines(font: Font, subroutinize: bool = True) -> None:
     if subroutinize:
         logger.info("Subroutinizing")
         font.ps_subroutinize()
-    font.modified = True
+    font.is_modified = True
 
 
 def round_coordinates(font: Font, subroutinize: bool = True) -> None:
@@ -84,7 +84,7 @@ def round_coordinates(font: Font, subroutinize: bool = True) -> None:
     if not result:
         return
 
-    font.modified = True
+    font.is_modified = True
     logger.info(f"{len(result)} glyphs were modified")
 
     if subroutinize:

--- a/foundrytools_cli_2/cli/post/tasks.py
+++ b/foundrytools_cli_2/cli/post/tasks.py
@@ -39,4 +39,4 @@ def set_attrs(
             old_value = getattr(post_table, attr)
             logger.info(f"{attr}: {old_value} -> {value}")
             setattr(post_table, attr, value)
-    font.modified = post_table.modified
+    font.is_modified = post_table.is_modified

--- a/foundrytools_cli_2/cli/task_runner.py
+++ b/foundrytools_cli_2/cli/task_runner.py
@@ -166,7 +166,7 @@ class TaskRunner:  # pylint: disable=too-few-public-methods
             self._save_font_to_file(font)
 
     def _font_should_be_saved(self, font: Font) -> bool:
-        return (self.save_if_modified and font.modified) or self.force_modified
+        return (self.save_if_modified and font.is_modified) or self.force_modified
 
     def _save_font_to_file(self, font: Font) -> None:
         try:

--- a/foundrytools_cli_2/cli/ttf/tasks/autohint.py
+++ b/foundrytools_cli_2/cli/ttf/tasks/autohint.py
@@ -27,4 +27,4 @@ def ttf_autohint(font: Font) -> None:
         hinted_font.flavor = flavor
         hinted_font[T_HEAD].modified = font.ttfont[T_HEAD].modified
         font.ttfont = hinted_font
-        font.modified = True
+        font.is_modified = True

--- a/foundrytools_cli_2/cli/ttf/tasks/dehint.py
+++ b/foundrytools_cli_2/cli/ttf/tasks/dehint.py
@@ -15,4 +15,4 @@ def ttf_dehint(font: Font) -> None:
         raise NotImplementedError("TTF de-hinting is only supported for TrueType fonts.")
 
     dehint(font.ttfont, verbose=False)
-    font.modified = True
+    font.is_modified = True

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -218,7 +218,7 @@ class Font:  # pylint: disable=too-many-public-methods
         return self._temp_file
 
     @property
-    def modified(self) -> bool:
+    def is_modified(self) -> bool:
         """
         Check if the font has been modified.
 
@@ -227,8 +227,8 @@ class Font:  # pylint: disable=too-many-public-methods
         """
         return self._modified
 
-    @modified.setter
-    def modified(self, value: bool) -> None:
+    @is_modified.setter
+    def is_modified(self, value: bool) -> None:
         """
         Set the modified flag of the font.
 

--- a/foundrytools_cli_2/lib/font/font.py
+++ b/foundrytools_cli_2/lib/font/font.py
@@ -37,6 +37,7 @@ from foundrytools_cli_2.lib.constants import (
     WOFF_FLAVOR,
 )
 from foundrytools_cli_2.lib.font.tables import CFFTable, HeadTable, NameTable, OS2Table
+from foundrytools_cli_2.lib.font.tables.cmap import CmapTable
 from foundrytools_cli_2.lib.otf.otf_autohint import hint_font
 from foundrytools_cli_2.lib.otf.otf_builder import build_otf
 from foundrytools_cli_2.lib.otf.t2_charstrings import quadratics_to_cubics, round_coordinates
@@ -803,7 +804,7 @@ class Font:  # pylint: disable=too-many-public-methods
 
     def tt_scale_upem(self, target_upm: int) -> None:
         """
-        Scale the font's Units Per Em (UPM).
+        Scale the Units Per Em (UPM) of a TrueType font.
 
         Args:
             target_upm (int): The new units per em value. Must be in the range 16 to 16384.
@@ -960,7 +961,7 @@ class Font:  # pylint: disable=too-many-public-methods
 
     def ps_round_coordinates(self) -> t.Set[str]:
         """
-        Round the coordinates of the outlines of a PostScript font.
+        Round the outlines coordinates of a PostScript font.
         """
         if not self.is_ps:
             raise NotImplementedError(
@@ -1113,7 +1114,7 @@ class Font:  # pylint: disable=too-many-public-methods
             cff_table.top_dict.charset = new_glyph_order
             cff_table.charstrings.charStrings = {k: charstrings.get(k) for k in new_glyph_order}
 
-    def remove_unreachable_glyphs(self, recalc_timestamp: bool = False) -> t.Set[str]:
+    def remove_unused_glyphs(self, recalc_timestamp: bool = False) -> t.Set[str]:
         """
         Remove glyphs that are not reachable by Unicode values or by substitution rules in the font.
 
@@ -1127,9 +1128,8 @@ class Font:  # pylint: disable=too-many-public-methods
         options = Options(**SUBSETTER_DEFAULTS)
         options.recalc_timestamp = recalc_timestamp
         old_glyph_order = self.ttfont.getGlyphOrder()
-        unicodes = set()
-        for table in self.ttfont[T_CMAP].tables:
-            unicodes.update(table.cmap.keys())
+        cmap_table = CmapTable(self.ttfont)
+        unicodes = cmap_table.get_codepoints()
         subsetter = Subsetter(options=options)
         subsetter.populate(unicodes=unicodes)
         subsetter.subset(self.ttfont)

--- a/foundrytools_cli_2/lib/font/tables/cmap.py
+++ b/foundrytools_cli_2/lib/font/tables/cmap.py
@@ -1,3 +1,5 @@
+import typing as t
+
 from fontTools.ttLib import TTFont
 
 from foundrytools_cli_2.lib.constants import T_CMAP
@@ -14,6 +16,16 @@ class CmapTable(DefaultTbl):  # pylint: disable=too-few-public-methods
         Initializes the ``cmap`` table handler.
         """
         super().__init__(ttfont=ttfont, table_tag=T_CMAP)
+
+    def get_codepoints(self) -> t.Set[int]:
+        """
+        Returns all the codepoints in the cmap table.
+        """
+        codepoints = set()
+        for table in self.table.tables:
+            if table.isUnicode():
+                codepoints.update(table.cmap.keys())
+        return codepoints
 
     def add_missing_non_breaking_space(self) -> None:
         """

--- a/foundrytools_cli_2/lib/font/tables/default.py
+++ b/foundrytools_cli_2/lib/font/tables/default.py
@@ -21,7 +21,7 @@ class DefaultTbl:
         self.table_copy = deepcopy(self.table)
 
     @property
-    def modified(self) -> bool:
+    def is_modified(self) -> bool:
         """
         Returns the modified status of the ``OS/2`` table by comparing it with the original table.
         """


### PR DESCRIPTION
This pull request involves a comprehensive refactor of the `font.modified` attribute to `font.is_modified` across multiple files in the `foundrytools_cli_2` project. The changes ensure consistency in how the modification state of a font is tracked.

### Refactor of `font.modified` to `font.is_modified`:

* [`foundrytools_cli_2/cli/cff/tasks.py`](diffhunk://#diff-76b70a1a6f12142e2e95a6d0f5a632d6575511fc99827de3ddfb9dcc7e6f61c6L18-R18): Updated methods `set_names`, `del_names`, and `find_replace` to use `font.is_modified` instead of `font.modified`. [[1]](diffhunk://#diff-76b70a1a6f12142e2e95a6d0f5a632d6575511fc99827de3ddfb9dcc7e6f61c6L18-R18) [[2]](diffhunk://#diff-76b70a1a6f12142e2e95a6d0f5a632d6575511fc99827de3ddfb9dcc7e6f61c6L32-R32) [[3]](diffhunk://#diff-76b70a1a6f12142e2e95a6d0f5a632d6575511fc99827de3ddfb9dcc7e6f61c6L47-R47)
* [`foundrytools_cli_2/cli/experimental/tasks/recalc_stems.py`](diffhunk://#diff-181e036aa2ba5ccc6fb87d144185c7c00c6c26aaa4a2849f0dd7aa4edab82f39L171-R171): Modified the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/experimental/tasks/recalc_zones.py`](diffhunk://#diff-a0804ecd94a1b463049cc65388c67f9bd57ca793c155b1e5934497359886d9d3L319-R319): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/contours.py`](diffhunk://#diff-636cff6aa1905594c279886546583c6ba14aa65e0f79efba5905d3b1b0e4957fL37-R37): Updated the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/decompose_transformed.py`](diffhunk://#diff-b9ea127bfd0009033954ebb06e387e64d460468216d5712fc740087e3601ca66L14-R14): Modified the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/duplicate_components.py`](diffhunk://#diff-fd8c7addc9dd59bc630209bdd47d8251271192ad39b2cabeb7aa9b7861842bd2L14-R14): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/empty_notdef.py`](diffhunk://#diff-dd151bbadf1f822e7c7e7d5b4b7646aa07d16d5f8b8c5cc476f246c9e4e1112aL128-R128): Updated the `fix_empty_notdef` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/fs_selection.py`](diffhunk://#diff-ef45177a1183975f12d2a263828590dd0977f19768dc52a0e48c8443941f74e7L16-R21): Modified the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/italic_angle.py`](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L50-R50): Updated multiple functions (`check_post_table`, `check_hhea_table`, `check_cff_table`, `check_italic_bits`, `check_oblique_bit`) to use `font.is_modified`. [[1]](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L50-R50) [[2]](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L76-R76) [[3]](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L99-R99) [[4]](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L125-R125) [[5]](diffhunk://#diff-e0729f005fb660ddbb21e6d2a76ad78507c325012aa9442b4e0834560b1e4b30L151-R151)
* [`foundrytools_cli_2/cli/fix/tasks/kern_table.py`](diffhunk://#diff-08cb008c12e98634bf3ecad0f720be3aaaac1e526be9ff22f79afef228663a13L14-R14): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/legacy_accents.py`](diffhunk://#diff-f75300c4b2aa999b1132e65cd6a7867d93af70af183c2d1c7977115f289d29caL57-R57): Updated the `fix_legacy_accents` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/monospace.py`](diffhunk://#diff-ee31d3a549ee5d0aaf2e5a6852f69eae12a27c8d1bd527c3325bba0dbaa2ef83L26-R33): Modified the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/nbsp_missing.py`](diffhunk://#diff-8e0cf26ef2c4c5db263039c2a0c864b11e96edc4ab2cbd7a796b3ce492a36c96L11-R11): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/nbsp_width.py`](diffhunk://#diff-fddf4f4db962fbce0884242bd9d4cbfbc80b29a7347f398eade1dd38fd59d9afL11-R11): Updated the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/fix/tasks/unreachable_glyphs.py`](diffhunk://#diff-0f0b7442d9ad8bb1d23fa3ef32ce3e1cd3131cfeeb12ed2ad06711b3a5f32760L15-R19): Modified the `main` function to use `font.is_modified` and renamed a method call from `remove_unreachable_glyphs` to `remove_unused_glyphs`.
* [`foundrytools_cli_2/cli/fix/tasks/vertical_metrics.py`](diffhunk://#diff-4fcc2d07581eb515353677d2f83517769b846da69fe9cf73042dd693313796aaL31-R31): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/glyphs/tasks/rebuild_cmap.py`](diffhunk://#diff-233cd8bf73bbfedb9b966210ed008f2be7829ead82092533293a21c206d554e5L42-R42): Updated the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/glyphs/tasks/rename_glyph.py`](diffhunk://#diff-f42623f1edbd4a16030622a9160f28430c2609aced1c9ecadebca47bdd4a4830L15-R15): Modified the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/glyphs/tasks/rename_glyphs.py`](diffhunk://#diff-243d8228de32115566a1e53b7f2735438a9aea31a8306e0add2931fc341287ddL28-R28): Changed the `main` function to use `font.is_modified`.
* [`foundrytools_cli_2/cli/glyphs/tasks/set_production_names.py`](diffhunk://#diff-46dc5f28381ba3be75765a05d87a12be1f47e107fb5c2ff97b845083806e7e52L28-R28): Updated the `main` function to use `font.is_modified`.