### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     zip_safe=False,
 )


### PR DESCRIPTION
This pull request updates the Python version compatibility for the project. The changes include modifying the supported Python versions in the CI configuration and the `setup.py` file.

Updates to Python version compatibility:

* [`.github/workflows/checks.yml`](diffhunk://#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L15-R15): Updated the matrix of Python versions to include Python 3.13 and remove Python 3.8.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L36-R36): Changed the minimum required Python version to 3.9.