### PR TITLE
pyupgrade

### DIFF
--- a/foundrytools_cli_2/cli/commands/cff.py
+++ b/foundrytools_cli_2/cli/commands/cff.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel
 from pathlib import Path
 from typing import Any, Callable
 

--- a/foundrytools_cli_2/cli/commands/cmap.py
+++ b/foundrytools_cli_2/cli/commands/cmap.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel
 from pathlib import Path
 from typing import Any
 

--- a/foundrytools_cli_2/cli/commands/fix/cli.py
+++ b/foundrytools_cli_2/cli/commands/fix/cli.py
@@ -1,6 +1,6 @@
 # pylint: disable=import-outside-toplevel
-import typing as t
 from pathlib import Path
+from typing import Any, cast
 
 import click
 from fontTools.misc.roundTools import otRound
@@ -14,7 +14,7 @@ cli = click.Group(help="Fix font errors.")
 
 
 @cli.command("duplicate-components", cls=BaseCommand)
-def fix_duplicate_components(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_duplicate_components(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Remove duplicate components.
 
@@ -51,7 +51,7 @@ def fix_duplicate_components(input_path: Path, **options: t.Dict[str, t.Any]) ->
 
 
 @cli.command("empty-notdef", cls=BaseCommand)
-def fix_empty_notdef(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_empty_notdef(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fixes the empty .notdef glyph by drawing a simple rectangle.
 
@@ -67,7 +67,7 @@ def fix_empty_notdef(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("fs-selection", cls=BaseCommand)
-def fix_fs_selection(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_fs_selection(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fixes the style flags (Regular, Italic, Bold) in the ``OS/2.fsSelection`` field and in the
     ``head.macStyle`` field.
@@ -101,7 +101,7 @@ def fix_fs_selection(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("kern-table", cls=BaseCommand)
-def fix_kern_table(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_kern_table(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fix the ``kern`` table by removing pairs that contain unmapped glyphs.
 
@@ -168,7 +168,7 @@ def fix_kern_table(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 \n
 """,
 )
-def fix_italic_angle(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_italic_angle(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fixes the italic angle and related attributes in the font.
 
@@ -203,7 +203,7 @@ def fix_italic_angle(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("legacy-accents", cls=BaseCommand)
-def fix_legacy_accents(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_legacy_accents(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Check that legacy accents aren't used in composite glyphs.
 
@@ -226,7 +226,7 @@ def fix_legacy_accents(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("nbsp-missing", cls=BaseCommand)
-def fix_missing_nbsp(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_missing_nbsp(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fixes the missing non-breaking space glyph by double mapping the space glyph.
 
@@ -250,7 +250,7 @@ def fix_missing_nbsp(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("nbsp-width", cls=BaseCommand)
-def fix_nbsp_width(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_nbsp_width(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fixes the width of the non-breaking space glyph to be the same as the space glyph.
 
@@ -283,7 +283,7 @@ def fix_nbsp_width(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("monospace", cls=BaseCommand)
-def fix_monospace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_monospace(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Fix metadata in monospaced fonts
 
@@ -341,7 +341,7 @@ def fix_monospace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("transformed-components", cls=BaseCommand)
-def fix_transformed_components(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_transformed_components(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Decompose glyphs with transformed components.
 
@@ -391,7 +391,7 @@ def fix_transformed_components(input_path: Path, **options: t.Dict[str, t.Any]) 
 
 
 @cli.command("unreachable-glyphs", cls=BaseCommand)
-def fix_unreachable_glyphs(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_unreachable_glyphs(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Remove unreachable glyphs from the font.
 
@@ -430,7 +430,7 @@ def fix_unreachable_glyphs(input_path: Path, **options: t.Dict[str, t.Any]) -> N
 
 
 @cli.command("vertical-metrics", cls=BaseCommand)
-def fix_vertical_metrics(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def fix_vertical_metrics(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Ensures that the vertical metrics are consistent across the font family.
 
@@ -451,8 +451,8 @@ def fix_vertical_metrics(input_path: Path, **options: t.Dict[str, t.Any]) -> Non
     safe_bottom = otRound(min(m[0] for m in metrics))
     safe_top = otRound(max(m[1] for m in metrics))
 
-    options["safe_bottom"] = t.cast(t.Any, safe_bottom)
-    options["safe_top"] = t.cast(t.Any, safe_top)
+    options["safe_bottom"] = cast(Any, safe_bottom)
+    options["safe_top"] = cast(Any, safe_top)
 
     from foundrytools_cli_2.cli.commands.fix.fix_vertical_metrics import main as task
 

--- a/foundrytools_cli_2/cli/commands/gsub.py
+++ b/foundrytools_cli_2/cli/commands/gsub.py
@@ -1,7 +1,5 @@
-# pylint: disable=import-outside-toplevel
-
-import typing as t
 from pathlib import Path
+from typing import Any
 
 import click
 from foundrytools import Font
@@ -28,7 +26,7 @@ cli = click.Group(help="Utilities for editing the ``GSUB`` table.")
     required=True,
     help="The new feature name.",
 )
-def rename_feature(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def rename_feature(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Remaps the feature tags in the GSUB table.
     """

--- a/foundrytools_cli_2/cli/commands/name.py
+++ b/foundrytools_cli_2/cli/commands/name.py
@@ -1,6 +1,5 @@
-# pylint: disable=import-outside-toplevel
-import typing as t
 from pathlib import Path
+from typing import Any, Optional
 
 import click
 from foundrytools import Font
@@ -48,16 +47,16 @@ cli = click.Group(help="Utilities for editing the ``name`` table.")
     Example: ``-l en`` will modify only NameRecords with language code "en".
     """,
 )
-def del_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def del_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Delete the specified NameRecords from the ``name`` table.
     """
 
     def task(
         font: Font,
-        name_ids_to_process: t.Tuple[int],
-        platform_id: t.Optional[int] = None,
-        language_string: t.Optional[str] = None,
+        name_ids_to_process: tuple[int],
+        platform_id: Optional[int] = None,
+        language_string: Optional[str] = None,
     ) -> bool:
         font.t_name.remove_names(
             name_ids=name_ids_to_process, platform_id=platform_id, language_string=language_string
@@ -69,7 +68,7 @@ def del_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("del-empty-names", cls=BaseCommand)
-def del_empty_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def del_empty_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Deletes empty NameRecords from the ``name`` table.
     """
@@ -83,7 +82,7 @@ def del_empty_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("del-mac-names", cls=BaseCommand)
-def del_mac_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def del_mac_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Delete Macintosh-specific NameRecords from the ``name`` table, excluding those with nameID 1, 2,
     4, 5 and 6. If the ``--del-all`` flag is set, all Macintosh-specific NameRecords are deleted.
@@ -98,7 +97,7 @@ def del_mac_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("del-unused-names", cls=BaseCommand)
-def del_unused_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def del_unused_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Delete unused NameRecords from the ``name`` table.
     """
@@ -163,7 +162,7 @@ def del_unused_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Example: ``-p 1`` will modify only NameRecords with platform ID 1.
     """,
 )
-def find_replace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def find_replace(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Find and replace text in the specified NameRecords.
     """
@@ -172,8 +171,8 @@ def find_replace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
         font: Font,
         old_string: str,
         new_string: str,
-        name_ids_to_process: t.Optional[t.Tuple[int]] = None,
-        name_ids_to_skip: t.Optional[t.Tuple[int]] = None,
+        name_ids_to_process: Optional[tuple[int]] = None,
+        name_ids_to_skip: Optional[tuple[int]] = None,
     ) -> bool:
         font.t_name.find_replace(
             old_string=old_string,
@@ -219,7 +218,7 @@ def find_replace(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Example: ``-p 1`` will only add NameRecords with platform ID 1.
     """,
 )
-def set_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def set_name(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Set the string of the specified NameRecord in the ``name`` table.
     """
@@ -228,7 +227,7 @@ def set_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
         font: Font,
         name_id: int,
         name_string: str,
-        platform_id: t.Optional[int] = None,
+        platform_id: Optional[int] = None,
         language_string: str = "en",
     ) -> bool:
         font.t_name.set_name(
@@ -244,7 +243,7 @@ def set_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("strip-names", cls=BaseCommand)
-def strip_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def strip_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Remove leading and trailing whitespace from the NameRecords.
     """
@@ -277,7 +276,7 @@ def strip_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Specify the platform ID to build the unique ID for.
     """,
 )
-def build_unique_id(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def build_unique_id(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Builds the NameID 3 (Unique ID).
 
@@ -290,7 +289,7 @@ def build_unique_id(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     ``Font Revision;Vendor ID;PostScript Name``
     """
 
-    def task(font: Font, platform_id: t.Optional[int] = None, alternate: bool = False) -> bool:
+    def task(font: Font, platform_id: Optional[int] = None, alternate: bool = False) -> bool:
         font.t_name.build_unique_identifier(platform_id=platform_id, alternate=alternate)
         return font.t_name.is_modified
 
@@ -309,12 +308,12 @@ def build_unique_id(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Specify the platform ID to build the Full Name for.
     """,
 )
-def build_full_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def build_full_name(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Builds the NameID 4 (Full Font Name).
     """
 
-    def task(font: Font, platform_id: t.Optional[int] = None) -> bool:
+    def task(font: Font, platform_id: Optional[int] = None) -> bool:
         font.t_name.build_full_font_name(platform_id=platform_id)
         return font.t_name.is_modified
 
@@ -333,12 +332,12 @@ def build_full_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Specify the platform ID to build the Version String for.
     """,
 )
-def build_version_string(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def build_version_string(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Builds the NameID 5 (Version String).
     """
 
-    def task(font: Font, platform_id: t.Optional[int] = None) -> bool:
+    def task(font: Font, platform_id: Optional[int] = None) -> bool:
         font.t_name.build_version_string(platform_id=platform_id)
         return font.t_name.is_modified
 
@@ -357,12 +356,12 @@ def build_version_string(input_path: Path, **options: t.Dict[str, t.Any]) -> Non
     Specify the platform ID to build the PostScript Name for.
     """,
 )
-def build_postscript_name(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def build_postscript_name(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Builds the NameID 6 (PostScript Name).
     """
 
-    def task(font: Font, platform_id: t.Optional[int] = None) -> bool:
+    def task(font: Font, platform_id: Optional[int] = None) -> bool:
         font.t_name.build_postscript_name(platform_id=platform_id)
         return font.t_name.is_modified
 
@@ -371,7 +370,7 @@ def build_postscript_name(input_path: Path, **options: t.Dict[str, t.Any]) -> No
 
 
 @cli.command("build-mac-names", cls=BaseCommand)
-def build_mac_names(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def build_mac_names(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Builds the Macintosh-specific names.
 

--- a/foundrytools_cli_2/cli/commands/os_2.py
+++ b/foundrytools_cli_2/cli/commands/os_2.py
@@ -1,5 +1,5 @@
-import typing as t
 from pathlib import Path
+from typing import Any, Optional, Union
 
 import click
 from fontTools.misc.roundTools import otRound
@@ -14,7 +14,7 @@ cli = click.Group(help="Utilities for editing the ``OS/2`` table.")
 
 
 @cli.command("recalc-avg-width", cls=BaseCommand)
-def recalc_avg_char_width(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_avg_char_width(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the xAvgCharWidth value of the OS/2 table.
     """
@@ -34,7 +34,7 @@ def recalc_avg_char_width(input_path: Path, **options: t.Dict[str, t.Any]) -> No
     default="x",
     help="The glyph name to use for calculating the x-height. Default is 'x'.",
 )
-def recalc_x_height(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_x_height(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the sxHeight value of the OS/2 table.
     """
@@ -54,7 +54,7 @@ def recalc_x_height(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     default="H",
     help="The glyph name to use for calculating the cap height. Default is 'H'.",
 )
-def recalc_cap_height(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_cap_height(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the sCapHeight value of the OS/2 table.
     """
@@ -68,7 +68,7 @@ def recalc_cap_height(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("recalc-max-context", cls=BaseCommand)
-def recalc_max_context(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_max_context(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the usMaxContext value of the OS/2 table.
     """
@@ -82,7 +82,7 @@ def recalc_max_context(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
 
 @cli.command("recalc-codepage-ranges", cls=BaseCommand)
-def recalc_codepage_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_codepage_ranges(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the ulCodePageRange values of the OS/2 table.
     """
@@ -103,7 +103,7 @@ def recalc_codepage_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> N
     default=33.0,
     help="Minimum percentage of coverage required for a Unicode range to be enabled.",
 )
-def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def recalc_unicode_ranges(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculates the ulUnicodeRange values of the OS/2 table based on a minimum percentage of
     coverage.
@@ -251,13 +251,13 @@ def recalc_unicode_ranges(input_path: Path, **options: t.Dict[str, t.Any]) -> No
     This field was defined in version 2 of the ``OS/2`` table.
     """,
 )
-def set_attrs(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def set_attrs(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Sets miscellaneous attributes of the OS/2 table.
     """
     ensure_at_least_one_param(click.get_current_context())
 
-    def task(font: Font, **kwargs: t.Dict[str, t.Optional[t.Union[int, float, str, bool]]]) -> bool:
+    def task(font: Font, **kwargs: dict[str, Optional[Union[int, float, str, bool]]]) -> bool:
         for attr, value in kwargs.items():
             if value is not None:
                 try:
@@ -411,13 +411,13 @@ def set_attrs(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Bit 9 was defined in version 4 of the ``OS/2`` table.
     """,
 )
-def set_fs_selection(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def set_fs_selection(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Sets flags in the fsSelection field of the OS/2 table.
     """
     ensure_at_least_one_param(click.get_current_context())
 
-    def task(font: Font, **kwargs: t.Dict[str, t.Optional[bool]]) -> bool:
+    def task(font: Font, **kwargs: dict[str, Optional[bool]]) -> bool:
         for attr, value in kwargs.items():
             if value is not None:
                 if hasattr(font.flags, attr):
@@ -491,13 +491,13 @@ def set_fs_selection(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     restrictions specified in bits 0-3 and 8 also apply.
     """,
 )
-def set_fs_type(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def set_fs_type(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Set font embedding licensing rights for the font, defined in the fsType field of the OS/2 table.
     """
     ensure_at_least_one_param(click.get_current_context())
 
-    def task(font: Font, **kwargs: t.Dict[str, t.Optional[bool]]) -> bool:
+    def task(font: Font, **kwargs: dict[str, Optional[bool]]) -> bool:
         for attr, value in kwargs.items():
             if hasattr(font.t_os_2, attr) and value is not None:
                 setattr(font.t_os_2, attr, value)
@@ -598,13 +598,13 @@ def set_fs_type(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     Sets the 'bXHeight' value.
     """,
 )
-def set_panose(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def set_panose(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Sets the PANOSE classification in the OS/2 table.
     """
     ensure_at_least_one_param(click.get_current_context())
 
-    def task(font: Font, **kwargs: t.Dict[str, int]) -> bool:
+    def task(font: Font, **kwargs: dict[str, int]) -> bool:
         for attr, value in kwargs.items():
             if hasattr(font.t_os_2.table.panose, attr) and value is not None:
                 setattr(font.t_os_2.table.panose, attr, value)
@@ -623,7 +623,7 @@ def set_panose(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
     The version of the OS/2 table to set.
     """,
 )
-def upgrade(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def upgrade(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Upgrades the OS/2 table version.
 

--- a/foundrytools_cli_2/cli/commands/otf.py
+++ b/foundrytools_cli_2/cli/commands/otf.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel
 from pathlib import Path
 from typing import Any, Callable, cast
 
@@ -7,6 +6,8 @@ from foundrytools import Font
 from foundrytools.app.otf_autohint import run as otf_autohint
 from foundrytools.app.otf_check_outlines import run as otf_check_outlines
 from foundrytools.app.otf_dehint import run as otf_dehint
+from foundrytools.app.otf_recalc_stems import run as get_stems
+from foundrytools.app.otf_recalc_zones import run as get_zones
 from foundrytools.utils.path_tools import get_temp_file_path
 
 from foundrytools_cli_2.cli import BaseCommand, make_options
@@ -255,7 +256,6 @@ def recalc_stems(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculate the hinting stems of OpenType-PS fonts.
     """
-    from foundrytools.app.otf_recalc_stems import run as get_stems
 
     def task(font: Font) -> bool:
         if not font.is_ps:
@@ -328,7 +328,6 @@ def recalc_zones(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Recalculate the hinting zones of OpenType-PS fonts.
     """
-    from foundrytools.app.otf_recalc_zones import run as get_zones
 
     def task(font: Font) -> bool:
         if not font.is_ps:

--- a/foundrytools_cli_2/cli/commands/post.py
+++ b/foundrytools_cli_2/cli/commands/post.py
@@ -1,5 +1,5 @@
-import typing as t
 from pathlib import Path
+from typing import Any, Optional
 
 import click
 from foundrytools import Font
@@ -35,7 +35,7 @@ from foundrytools_cli_2.cli.task_runner import TaskRunner
     default=None,
     help="""Sets or clears the `isFixedPitch` value.""",
 )
-def cli(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
+def cli(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Utilities for editing the ``post`` table.
     """
@@ -43,10 +43,10 @@ def cli(input_path: Path, **options: t.Dict[str, t.Any]) -> None:
 
     def task(
         font: Font,
-        italic_angle: t.Optional[float] = None,
-        underline_position: t.Optional[int] = None,
-        underline_thickness: t.Optional[int] = None,
-        fixed_pitch: t.Optional[bool] = None,
+        italic_angle: Optional[float] = None,
+        underline_position: Optional[int] = None,
+        underline_thickness: Optional[int] = None,
+        fixed_pitch: Optional[bool] = None,
     ) -> bool:
         attrs = {
             "italic_angle": italic_angle,

--- a/foundrytools_cli_2/cli/commands/ttf.py
+++ b/foundrytools_cli_2/cli/commands/ttf.py
@@ -1,9 +1,10 @@
-# pylint: disable=import-outside-toplevel
 from pathlib import Path
 from typing import Any
 
 import click
 from foundrytools import Font
+from foundrytools.app.ttf_autohint import run as ttf_autohint
+from foundrytools.app.ttf_dehint import run as ttf_dehint
 
 from foundrytools_cli_2.cli import BaseCommand
 from foundrytools_cli_2.cli.logger import logger
@@ -17,9 +18,8 @@ def autohint(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Auto-hints the given TrueType fonts using ttfautohint-py.
     """
-    from foundrytools.app.ttf_autohint import run as task
 
-    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner = TaskRunner(input_path=input_path, task=ttf_autohint, **options)
     runner.filter.filter_out_ps = True
     runner.run()
 
@@ -29,9 +29,8 @@ def dehint(input_path: Path, **options: dict[str, Any]) -> None:
     """
     Removes hinting from the given TrueType fonts.
     """
-    from foundrytools.app.ttf_dehint import run as task
 
-    runner = TaskRunner(input_path=input_path, task=task, **options)
+    runner = TaskRunner(input_path=input_path, task=ttf_dehint, **options)
     runner.filter.filter_out_ps = True
     runner.run()
 

--- a/foundrytools_cli_2/cli/commands/utils/sync_timestamps.py
+++ b/foundrytools_cli_2/cli/commands/utils/sync_timestamps.py
@@ -1,7 +1,6 @@
 # pylint: disable=import-outside-toplevel
 import os
 import platform
-import typing as t
 from pathlib import Path
 
 from fontTools.misc.timeTools import epoch_diff, timestampToString
@@ -37,9 +36,7 @@ def _is_relative_to(path: Path, other: Path) -> bool:
         return False
 
 
-def _get_file_timestamps(
-    input_path: Path, recursive: bool = True
-) -> t.Dict[Path, t.Tuple[int, int]]:
+def _get_file_timestamps(input_path: Path, recursive: bool = True) -> dict[Path, tuple[int, int]]:
     finder = FontFinder(input_path)
     finder.options.recursive = recursive
     fonts = finder.find_fonts()
@@ -54,9 +51,9 @@ def _get_file_timestamps(
 
 
 def _get_folder_timestamps(
-    folders: t.Set[Path],
-    files_timestamps: t.Dict[Path, t.Tuple[int, int]],
-) -> t.Dict[Path, t.Tuple[int, int]]:
+    folders: set[Path],
+    files_timestamps: dict[Path, tuple[int, int]],
+) -> dict[Path, tuple[int, int]]:
     folder_timestamps = {
         folder: (
             min(
@@ -80,7 +77,7 @@ def _get_folder_timestamps(
     return folder_timestamps
 
 
-def _set_timestamps(path_timestamps: t.Dict[Path, t.Tuple[int, int]]) -> None:
+def _set_timestamps(path_timestamps: dict[Path, tuple[int, int]]) -> None:
     for path, timestamps in path_timestamps.items():
         logger.opt(colors=True).info(f"Current path: <light-cyan>{path}</>")
 

--- a/foundrytools_cli_2/cli/task_runner.py
+++ b/foundrytools_cli_2/cli/task_runner.py
@@ -1,6 +1,6 @@
-import typing as t
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Callable, Optional, Union, get_type_hints
 
 from foundrytools import Font
 from foundrytools.lib.font_finder import (
@@ -28,9 +28,9 @@ class SaveOptions:
     A class that specifies how to save the font.
     """
 
-    reorder_tables: t.Optional[bool] = True
+    reorder_tables: Optional[bool] = True
     suffix: str = ""
-    output_dir: t.Optional[Path] = None
+    output_dir: Optional[Path] = None
     overwrite: bool = False
 
 
@@ -39,42 +39,42 @@ class TaskRunnerConfig:  # pylint: disable=too-few-public-methods
     Handle options for TaskRunner.
     """
 
-    def __init__(self, task_callable: t.Callable, options: t.Dict[str, t.Any]):
+    def __init__(self, task_callable: Callable, options: dict[str, Any]):
         self.task = task_callable
         self.filter = FinderFilter()
         self.finder_options = FinderOptions()
         self.save_options = SaveOptions()
-        self.task_options: t.Dict[str, t.Any] = {}
+        self.task_options: dict[str, Any] = {}
         self._handle_options(options)
 
-    def _handle_options(self, options: t.Dict[str, t.Any]) -> None:
+    def _handle_options(self, options: dict[str, Any]) -> None:
         self._parse_finder_options(options)
         self._parse_save_options(options)
         self._parse_task_options(options)
 
-    def _parse_finder_options(self, options: t.Dict[str, t.Any]) -> None:
+    def _parse_finder_options(self, options: dict[str, Any]) -> None:
         self._set_options(self.finder_options, options)
 
-    def _parse_save_options(self, options: t.Dict[str, t.Any]) -> None:
+    def _parse_save_options(self, options: dict[str, Any]) -> None:
         self._set_options(self.save_options, options)
 
-    def _parse_task_options(self, options: t.Dict[str, t.Any]) -> None:
-        if "kwargs" in t.get_type_hints(self.task):
+    def _parse_task_options(self, options: dict[str, Any]) -> None:
+        if "kwargs" in get_type_hints(self.task):
             self.task_options.update(
                 {
                     k: v
                     for k, v in options.items()
-                    if k not in t.get_type_hints(FinderOptions)
-                    and k not in t.get_type_hints(SaveOptions)
+                    if k not in get_type_hints(FinderOptions)
+                    and k not in get_type_hints(SaveOptions)
                 }
             )
         for key, value in options.items():
-            if key in t.get_type_hints(self.task):
+            if key in get_type_hints(self.task):
                 self.task_options.update({key: value})
 
     @staticmethod
     def _set_options(
-        options_group: t.Union[dict, FinderOptions, SaveOptions], options: t.Dict[str, t.Any]
+        options_group: Union[dict, FinderOptions, SaveOptions], options: dict[str, Any]
     ) -> None:
         """
         Update attributes of an options_group with provided options if the attribute exists.
@@ -104,8 +104,8 @@ class TaskRunner:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         input_path: Path,
-        task: t.Callable,
-        **options: t.Dict[str, t.Any],
+        task: Callable,
+        **options: dict[str, Any],
     ) -> None:
         """
         Initialize a new instance of the class.
@@ -140,7 +140,7 @@ class TaskRunner:  # pylint: disable=too-few-public-methods
         for font in fonts:
             self._process_font(font, timer=timer)
 
-    def _find_fonts(self) -> t.List[Font]:
+    def _find_fonts(self) -> list[Font]:
         finder = FontFinder(
             input_path=self.input_path, options=self.config.finder_options, filter_=self.filter
         )


### PR DESCRIPTION
This pull request includes several changes to the `foundrytools_cli_2` project, focusing on improving type hinting and removing unnecessary imports. The most important changes involve updating type annotations and removing the `pylint` disable comments for import statements.

### Type Hinting Improvements:

* Updated type annotations in `foundrytools_cli_2/cli/commands/fix/cli.py` to use `dict[str, Any]` instead of `t.Dict[str, t.Any]` and `cast` from `typing` instead of `t.cast`. [[1]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L17-R17) [[2]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L54-R54) [[3]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L70-R70) [[4]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L104-R104) [[5]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L171-R171) [[6]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L206-R206) [[7]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L229-R229) [[8]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L253-R253) [[9]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L286-R286) [[10]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L344-R344) [[11]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L394-R394) [[12]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L433-R433) [[13]](diffhunk://#diff-a31942a0d165891a41676d08a9d16a21aead8f17a2df77a54617b793b6abfb99L454-R455)
* Updated type annotations in `foundrytools_cli_2/cli/commands/name.py` to use `dict[str, Any]` and `Optional` from `typing`. [[1]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L51-R59) [[2]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L72-R71) [[3]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L86-R85) [[4]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L101-R100) [[5]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L166-R165) [[6]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L222-R221) [[7]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L231-R230) [[8]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L247-R246) [[9]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L280-R279) [[10]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L293-R292) [[11]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L312-R316) [[12]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L336-R340) [[13]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L360-R364) [[14]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L374-R373)

### Import Cleanup:

* Removed unnecessary `pylint` disable comments for import statements in multiple files (`cff.py`, `cmap.py`, `gsub.py`, `name.py`). [[1]](diffhunk://#diff-c2b1cde023c09ad4dbc661b6ecf3b93e4556988c99e33d1f8ab9985c664b90cbL1) [[2]](diffhunk://#diff-02e8a96233d5826308e56405cac20f0f6a99ab530fd12ebddfa00d7d1e15e90aL1) [[3]](diffhunk://#diff-ac04528d6af5b37e2ebba7b9c387dc561e3315f31b8ed07f092b0a47e3a957f3L1-R2) [[4]](diffhunk://#diff-4d9cfe17551562e7d609002f5c213409de0e4d6b0b4ab9b4a3a379e9314551a2L1-R2)
* Removed `typing as t` imports and replaced with specific imports from `typing` in `gsub.py` and `os_2.py`. [[1]](diffhunk://#diff-ac04528d6af5b37e2ebba7b9c387dc561e3315f31b8ed07f092b0a47e3a957f3L1-R2) [[2]](diffhunk://#diff-c61c2166ab87d77a4edaa5fcbc93e7b0b5e14fa5093b2af7d11b72fb6c237d99L1-R2)